### PR TITLE
fix for the zeros / NA discrepancy 

### DIFF
--- a/alphastats/DataSet_Preprocess.py
+++ b/alphastats/DataSet_Preprocess.py
@@ -158,20 +158,20 @@ class Preprocess:
         )
         self.preprocessing_info.update({"Imputation": method})
 
-    def _linear_normalization(self, array):
+    def _linear_normalization(self, dataframe: pd.DataFrame):
         """Normalize data using l2 norm without breaking when encoutering nones
         l2 = sqrt(sum(x**2))
 
         Args:
-            array (pd.Series): array to normalize (1D array)
+            dataframe (pd.DataFrame): dataframe to normalize
 
         Returns:
-            np.array: normalized array
+            np.array: normalized np.array
         """
-        square_sum_per_row = array.pow(2).sum(axis=1, skipna=True)
+        square_sum_per_row = dataframe.pow(2).sum(axis=1, skipna=True)
 
         l2_norms = np.sqrt(square_sum_per_row)
-        normalized_vals = array.div(l2_norms.replace(0, 1), axis=0)
+        normalized_vals = dataframe.div(l2_norms.replace(0, 1), axis=0)
         return normalized_vals.values
 
     @ignore_warning(UserWarning)

--- a/alphastats/DataSet_Preprocess.py
+++ b/alphastats/DataSet_Preprocess.py
@@ -1,15 +1,15 @@
-from random import random
+import itertools
+import logging
+
+import numpy as np
 import pandas as pd
 import sklearn
-import logging
-import numpy as np
 import sklearn.ensemble
 import sklearn.impute
-from alphastats.utils import ignore_warning
-from sklearn.experimental import enable_iterative_imputer
-import itertools
-
 import streamlit as st
+
+from sklearn.experimental import enable_iterative_imputer
+from alphastats.utils import ignore_warning
 
 
 class Preprocess:
@@ -31,9 +31,14 @@ class Preprocess:
         print(pd.DataFrame(self.preprocessing_info.items()))
 
     def _remove_na_values(self, cut_off):
-        if self.preprocessing_info.get("Missing values were removed") and self.preprocessing_info.get("Data completeness cut-off") == cut_off:
+        if (
+            self.preprocessing_info.get("Missing values were removed")
+            and self.preprocessing_info.get("Data completeness cut-off") == cut_off
+        ):
             logging.info("Missing values have already been filtered.")
-            st.warning("Missing values have already been filtered. To apply another cutoff, reset preprocessing.")
+            st.warning(
+                "Missing values have already been filtered. To apply another cutoff, reset preprocessing."
+            )
             return
         cut = 1 - cut_off
 
@@ -59,25 +64,25 @@ class Preprocess:
 
         self.preprocessing_info.update(
             {
-                "Number of removed ProteinGroups due to data completeness cutoff": num_proteins - self.mat.shape[1],
+                "Number of removed ProteinGroups due to data completeness cutoff": num_proteins
+                - self.mat.shape[1],
                 "Missing values were removed": True,
                 "Data completeness cut-off": cut_off,
             }
         )
-       
 
     def _filter(self):
         if len(self.filter_columns) == 0:
             logging.info("No columns to filter.")
             return
 
-        if self.preprocessing_info.get("Contaminations have been removed") == True:
+        if self.preprocessing_info.get("Contaminations have been removed"):
             logging.info("Contaminatons have already been filtered.")
             return
 
         #  print column names with contamination
         protein_groups_to_remove = self.rawinput[
-            (self.rawinput[self.filter_columns] == True).any(axis=1)
+            self.rawinput[self.filter_columns].any(axis=1)
         ][self.index_column].tolist()
 
         protein_groups_to_remove = list(
@@ -186,10 +191,11 @@ class Preprocess:
     @ignore_warning(UserWarning)
     @ignore_warning(RuntimeWarning)
     def _normalization(self, method: str):
-
         if method == "zscore":
             scaler = sklearn.preprocessing.StandardScaler()
-            normalized_array = scaler.fit_transform(self.mat.values.transpose()).transpose()
+            normalized_array = scaler.fit_transform(
+                self.mat.values.transpose()
+            ).transpose()
 
         elif method == "quantile":
             qt = sklearn.preprocessing.QuantileTransformer(random_state=0)
@@ -268,7 +274,6 @@ class Preprocess:
         Args:
             batch (str): column name in the metadata describing the different batches
         """
-        import combat
         from combat.pycombat import pycombat
 
         data = self.mat.transpose()

--- a/alphastats/DataSet_Preprocess.py
+++ b/alphastats/DataSet_Preprocess.py
@@ -8,7 +8,7 @@ import sklearn.ensemble
 import sklearn.impute
 import streamlit as st
 
-from sklearn.experimental import enable_iterative_imputer
+from sklearn.experimental import enable_iterative_imputer #noqa
 from alphastats.utils import ignore_warning
 
 
@@ -140,25 +140,11 @@ class Preprocess:
             imputation_array = imp.fit_transform(self.mat.values)
 
         elif method == "randomforest":
-            randomforest = sklearn.ensemble.RandomForestRegressor(
-                max_depth=10,
-                bootstrap=True,
-                max_samples=0.5,
-                n_jobs=2,
-                random_state=0,
-                verbose=0,  #  random forest takes a while print progress
+            imp = sklearn.ensemble.HistGradientBoostingRegressor(
+                max_depth=10, max_iter=100, random_state=0
             )
-            imp = sklearn.impute.IterativeImputer(
-                random_state=0, estimator=randomforest
-            )
-
-            # the random forest imputer doesnt work with float32/float16..
-            #  so the values are multiplied and converted to integers
-            array_multi_mio = self.mat.values * 1000000
-            array_int = array_multi_mio.astype("int")
-
-            imputation_array = imp.fit_transform(array_int)
-            imputation_array = imputation_array / 1000000
+            imp = sklearn.impute.IterativeImputer(random_state=0, estimator=imp)
+            imputation_array = imp.fit_transform(self.mat.values)
 
         else:
             raise ValueError(

--- a/alphastats/gui/pages/02_Import Data.py
+++ b/alphastats/gui/pages/02_Import Data.py
@@ -42,7 +42,7 @@ if "gene_to_prot_id" not in st.session_state:
     st.session_state["gene_to_prot_id"] = {}
 
 if "organism" not in st.session_state:
-    st.session_state["organism"] = 9606
+    st.session_state["organism"] = 9606 # human
 
 
 def load_options():

--- a/alphastats/gui/pages/03_Preprocessing.py
+++ b/alphastats/gui/pages/03_Preprocessing.py
@@ -12,7 +12,7 @@ def preprocessing():
 
         st.markdown(
             "Before analyzing your data, consider normalizing and imputing your data as well as the removal of contaminants. "
-            + "A more detailed description about the preprocessing methods can be found in the AlphaPeptStats "
+            + "A more detailed description about the preprocessing methods can be found in the AlphaPeptStats " 
             + "[documentation](https://alphapeptstats.readthedocs.io/en/main/data_preprocessing.html)."
         )
 
@@ -30,23 +30,17 @@ def preprocessing():
             )
 
             remove_samples = st.multiselect(
-                "Remove samples from analysis",
-                options=st.session_state.dataset.metadata[
-                    st.session_state.dataset.sample
-                ].to_list(),
+                "Remove samples from analysis", 
+                options=st.session_state.dataset.metadata[st.session_state.dataset.sample].to_list()
             )
 
             data_completeness = st.number_input(
                 f"Data completeness across samples cut-off \n(0.7 -> protein has to be detected in at least 70% of the samples)",
-                value=0.0,
-                min_value=0.0,
-                max_value=1.0,
-                step=0.1,
+                value=0, min_value=0, max_value=1
             )
 
             log2_transform = st.selectbox(
-                "Log2-transform dataset",
-                options=[True, False],
+                "Log2-transform dataset", options=[True, False],
             )
 
             normalization = st.selectbox(
@@ -62,64 +56,57 @@ def preprocessing():
         if submitted:
             if len(remove_samples) == 0:
                 remove_samples = None
-
+            
             st.session_state.dataset.preprocess(
                 remove_contaminations=remove_contaminations,
                 log2_transform=log2_transform,
-                remove_samples=remove_samples,
+                remove_samples = remove_samples,
                 data_completeness=data_completeness,
                 subset=subset,
                 normalization=normalization,
                 imputation=imputation,
             )
-             
-            st.session_state["preprocessing_info"] = st.session_state.dataset.preprocessing_info
-            
-
-    if submitted or "preprocessing_info" in st.session_state:
-        st.info(
+            preprocessing = st.session_state.dataset.preprocessing_info
+            st.info(
                 "Data has been processed. "
                 + datetime.datetime.now().strftime("%d/%m/%Y %H:%M:%S")
             )
-        st.dataframe(
-                pd.DataFrame.from_dict(st.session_state["preprocessing_info"], orient="index").astype(str),
+            st.dataframe(
+                pd.DataFrame.from_dict(preprocessing, orient="index").astype(str),
                 use_container_width=True,
             )
-    with c2:
-
-        if submitted:
-            st.markdown("**Intensity Distribution after preprocessing per sample**")
-            fig_processed = st.session_state.dataset.plot_sampledistribution()
-            st.plotly_chart(
-                fig_processed.update_layout(plot_bgcolor="white"),
-                use_container_width=True,
-            )
-
-        else:
-            st.markdown("**Intensity Distribution per sample**")
-            fig_none_processed = st.session_state.dataset.plot_sampledistribution()
-            st.plotly_chart(
-                fig_none_processed.update_layout(plot_bgcolor="white"),
-                use_container_width=True,
-            )
-    c1, c2 = st.columns(2)
-    with c1:    
+        
         st.markdown("#### Batch correction: correct for technical bias")
 
         with st.form("Batch correction: correct for technical bias"):
             batch = st.selectbox(
-                "Batch", options=st.session_state.dataset.metadata.columns.to_list()
+                "Batch", 
+                options= st.session_state.dataset.metadata.columns.to_list()
             )
             submit_batch_correction = st.form_submit_button("Submit")
-
+        
         if submit_batch_correction:
-            st.session_state.dataset.batch_correction(batch=batch)
+            st.session_state.dataset.batch_correction(
+                batch=batch
+            )
             st.info(
                 "Data has been processed. "
                 + datetime.datetime.now().strftime("%d/%m/%Y %H:%M:%S")
             )
 
     
+    with c2:
+
+        if submitted:
+            st.markdown("**Intensity Distribution after preprocessing per sample**")
+            fig_processed = st.session_state.dataset.plot_sampledistribution()
+            st.plotly_chart(fig_processed.update_layout(plot_bgcolor="white"), use_container_width=True)
+        
+        else:
+            st.markdown("**Intensity Distribution per sample**")
+            fig_none_processed = st.session_state.dataset.plot_sampledistribution()
+            st.plotly_chart(fig_none_processed.update_layout(plot_bgcolor="white"), use_container_width=True)
+        
 
     reset_steps = st.button("Reset all Preprocessing steps")
 
@@ -129,12 +116,14 @@ def preprocessing():
 
 def reset_preprocessing():
     st.session_state.dataset.create_matrix()
+    preprocessing = st.session_state.dataset.preprocessing_info
     st.info(
         "Data has been reset. " + datetime.datetime.now().strftime("%d/%m/%Y %H:%M:%S")
     )
-    st.session_state["preprocessing_info"] = st.session_state.dataset.preprocessing_info
-    # reset the page
-    st.rerun()
+    st.dataframe(
+        pd.DataFrame.from_dict(preprocessing, orient="index").astype(str),
+        use_container_width=True,
+    )
 
 
 def main_preprocessing():

--- a/alphastats/gui/pages/03_Preprocessing.py
+++ b/alphastats/gui/pages/03_Preprocessing.py
@@ -12,7 +12,7 @@ def preprocessing():
 
         st.markdown(
             "Before analyzing your data, consider normalizing and imputing your data as well as the removal of contaminants. "
-            + "A more detailed description about the preprocessing methods can be found in the AlphaPeptStats " 
+            + "A more detailed description about the preprocessing methods can be found in the AlphaPeptStats "
             + "[documentation](https://alphapeptstats.readthedocs.io/en/main/data_preprocessing.html)."
         )
 
@@ -30,17 +30,23 @@ def preprocessing():
             )
 
             remove_samples = st.multiselect(
-                "Remove samples from analysis", 
-                options=st.session_state.dataset.metadata[st.session_state.dataset.sample].to_list()
+                "Remove samples from analysis",
+                options=st.session_state.dataset.metadata[
+                    st.session_state.dataset.sample
+                ].to_list(),
             )
 
             data_completeness = st.number_input(
                 f"Data completeness across samples cut-off \n(0.7 -> protein has to be detected in at least 70% of the samples)",
-                value=0, min_value=0, max_value=1
+                value=0.0,
+                min_value=0.0,
+                max_value=1.0,
+                step=0.1,
             )
 
             log2_transform = st.selectbox(
-                "Log2-transform dataset", options=[True, False],
+                "Log2-transform dataset",
+                options=[True, False],
             )
 
             normalization = st.selectbox(
@@ -56,57 +62,64 @@ def preprocessing():
         if submitted:
             if len(remove_samples) == 0:
                 remove_samples = None
-            
+
             st.session_state.dataset.preprocess(
                 remove_contaminations=remove_contaminations,
                 log2_transform=log2_transform,
-                remove_samples = remove_samples,
+                remove_samples=remove_samples,
                 data_completeness=data_completeness,
                 subset=subset,
                 normalization=normalization,
                 imputation=imputation,
             )
-            preprocessing = st.session_state.dataset.preprocessing_info
-            st.info(
+             
+            st.session_state["preprocessing_info"] = st.session_state.dataset.preprocessing_info
+            
+
+    if submitted or "preprocessing_info" in st.session_state:
+        st.info(
                 "Data has been processed. "
                 + datetime.datetime.now().strftime("%d/%m/%Y %H:%M:%S")
             )
-            st.dataframe(
-                pd.DataFrame.from_dict(preprocessing, orient="index").astype(str),
+        st.dataframe(
+                pd.DataFrame.from_dict(st.session_state["preprocessing_info"], orient="index").astype(str),
                 use_container_width=True,
             )
-        
+    with c2:
+
+        if submitted:
+            st.markdown("**Intensity Distribution after preprocessing per sample**")
+            fig_processed = st.session_state.dataset.plot_sampledistribution()
+            st.plotly_chart(
+                fig_processed.update_layout(plot_bgcolor="white"),
+                use_container_width=True,
+            )
+
+        else:
+            st.markdown("**Intensity Distribution per sample**")
+            fig_none_processed = st.session_state.dataset.plot_sampledistribution()
+            st.plotly_chart(
+                fig_none_processed.update_layout(plot_bgcolor="white"),
+                use_container_width=True,
+            )
+    c1, c2 = st.columns(2)
+    with c1:    
         st.markdown("#### Batch correction: correct for technical bias")
 
         with st.form("Batch correction: correct for technical bias"):
             batch = st.selectbox(
-                "Batch", 
-                options= st.session_state.dataset.metadata.columns.to_list()
+                "Batch", options=st.session_state.dataset.metadata.columns.to_list()
             )
             submit_batch_correction = st.form_submit_button("Submit")
-        
+
         if submit_batch_correction:
-            st.session_state.dataset.batch_correction(
-                batch=batch
-            )
+            st.session_state.dataset.batch_correction(batch=batch)
             st.info(
                 "Data has been processed. "
                 + datetime.datetime.now().strftime("%d/%m/%Y %H:%M:%S")
             )
 
     
-    with c2:
-
-        if submitted:
-            st.markdown("**Intensity Distribution after preprocessing per sample**")
-            fig_processed = st.session_state.dataset.plot_sampledistribution()
-            st.plotly_chart(fig_processed.update_layout(plot_bgcolor="white"), use_container_width=True)
-        
-        else:
-            st.markdown("**Intensity Distribution per sample**")
-            fig_none_processed = st.session_state.dataset.plot_sampledistribution()
-            st.plotly_chart(fig_none_processed.update_layout(plot_bgcolor="white"), use_container_width=True)
-        
 
     reset_steps = st.button("Reset all Preprocessing steps")
 
@@ -116,14 +129,12 @@ def preprocessing():
 
 def reset_preprocessing():
     st.session_state.dataset.create_matrix()
-    preprocessing = st.session_state.dataset.preprocessing_info
     st.info(
         "Data has been reset. " + datetime.datetime.now().strftime("%d/%m/%Y %H:%M:%S")
     )
-    st.dataframe(
-        pd.DataFrame.from_dict(preprocessing, orient="index").astype(str),
-        use_container_width=True,
-    )
+    st.session_state["preprocessing_info"] = st.session_state.dataset.preprocessing_info
+    # reset the page
+    st.rerun()
 
 
 def main_preprocessing():

--- a/tests/test_DataSet.py
+++ b/tests/test_DataSet.py
@@ -352,9 +352,9 @@ class TestAlphaPeptDataSet(BaseTestDataSet.BaseTest):
         self.obj.preprocess(log2_transform=False, imputation="randomforest")
         expected_mat = pd.DataFrame(
             {
-                "a": [2.00000000e00, 0, 4.00000000e00],
-                "b": [5.00000000e00, 4.00000000e00, 4.0],
-                "c": [0, 1.00000000e01, 0],
+                "a": [2.0, 3.0, 4.0],
+                "b": [5.0, 4.0, 4.0],
+                "c": [10.0, 10.0, 10.0],
             }
         )
         pd._testing.assert_frame_equal(self.obj.mat, expected_mat)

--- a/tests/test_DataSet.py
+++ b/tests/test_DataSet.py
@@ -270,9 +270,9 @@ class TestAlphaPeptDataSet(BaseTestDataSet.BaseTest):
         self.obj.preprocess(log2_transform=False, normalization="zscore")
         expected_mat = pd.DataFrame(
             {
-                "a": [-1.33630621, 1.06904497, 0.26726124],
-                "b": [1.41421356, -0.70710678, -0.70710678],
-                "c": [-1.38873015, 0.9258201, 0.46291005],
+                "a": [-0.162221, -0.508001, -0.707107],
+                "b": [1.297771, -0.889001, -0.707107],
+                "c": [-1.135550, 1.397001, 1.414214],
             }
         )
         pd._testing.assert_frame_equal(self.obj.mat, expected_mat)
@@ -282,7 +282,9 @@ class TestAlphaPeptDataSet(BaseTestDataSet.BaseTest):
         # Quantile Normalization
         self.obj.preprocess(log2_transform=False, normalization="quantile")
         expected_mat = pd.DataFrame(
-            {"a": [0.0, 1.0, 0.5], "b": [1.0, 0.0, 0.0], "c": [0.0, 1.0, 0.5]}
+            {"a": [0.5, 0.5, 0.0], 
+             "b": [1.0, 0.0, 0.0], 
+             "c": [0.0, 1.0, 1.0]}
         )
         pd._testing.assert_frame_equal(self.obj.mat, expected_mat)
 
@@ -306,9 +308,9 @@ class TestAlphaPeptDataSet(BaseTestDataSet.BaseTest):
         self.obj.preprocess(log2_transform=False, normalization="vst")
         expected_mat = pd.DataFrame(
             {
-                "a": [-1.307734, 1.120100, 0.187634],
-                "b": [	1.414214, -0.707107, -0.707107],
-                "c": [-1.360307, 1.015077, 0.345230],
+                "a": [-0.009526, -0.236399, -0.707107],
+                "b": [	1.229480, -1.089313, -0.707107],
+                "c": [-1.219954, 1.325712, 1.414214],
             }
         )
         pd._testing.assert_frame_equal(self.obj.mat.round(2), expected_mat.round(2))
@@ -507,7 +509,7 @@ class TestMaxQuantDataSet(BaseTestDataSet.BaseTest):
         )
         plot_dict = plot.to_plotly_json()
         self.assertEqual(len(plot_dict.get("data")), 5)
-        mock.assert_called_once()
+        self.assertEqual(mock.call_count, 2)
 
     def test_anova_with_tukey(self):
         # with first 100 protein ids
@@ -577,8 +579,8 @@ class TestMaxQuantDataSet(BaseTestDataSet.BaseTest):
         )
 
         # fdr lines get drawn
-        line_1 = plot.to_plotly_json()["data"][3].get("line").get("shape")
-        line_2 = plot.to_plotly_json()["data"][4].get("line").get("shape")
+        line_1 = plot.to_plotly_json()["data"][-2].get("line").get("shape")
+        line_2 = plot.to_plotly_json()["data"][-1].get("line").get("shape")
 
         self.assertEqual(line_1, "spline")
         self.assertEqual(line_2, "spline")
@@ -739,10 +741,10 @@ class TestMaxQuantDataSet(BaseTestDataSet.BaseTest):
         self.assertEqual(312, len(fig["data"]))
 
     def test_batch_correction(self):
-        self.obj.preprocess(subset=True, imputation="knn", normalization="quantile")
+        self.obj.preprocess(subset=True, imputation="knn", normalization="linear")
         self.obj.batch_correction(batch="batch_artifical_added")
         first_value = self.obj.mat.values[0, 0]
-        self.assertAlmostEqual(0.0111, first_value, places=2)
+        self.assertAlmostEqual(-0.00555, first_value, places=3)
 
     def test_multicova_analysis_invalid_covariates(self):
         self.obj.preprocess(imputation="knn", normalization="zscore", subset=True)

--- a/tests/test_DataSet.py
+++ b/tests/test_DataSet.py
@@ -237,7 +237,11 @@ class TestAlphaPeptDataSet(BaseTestDataSet.BaseTest):
         df = pd.DataFrame(
             {"sample": ["A", "B", "C"], "b": ["disease", "health", "disease"]}
         )
-        obj = DataSet(loader=self.loader, metadata_path=df, sample_column="sample",)
+        obj = DataSet(
+            loader=self.loader,
+            metadata_path=df,
+            sample_column="sample",
+        )
         #  is sample C removed
         self.assertEqual(self.obj.metadata.shape, (2, 2))
         mock.assert_called_once()
@@ -247,7 +251,11 @@ class TestAlphaPeptDataSet(BaseTestDataSet.BaseTest):
             df = pd.read_csv(self.metadata_path)
         else:
             df = pd.read_excel(self.metadata_path)
-        obj = DataSet(loader=self.loader, metadata_path=df, sample_column="sample",)
+        obj = DataSet(
+            loader=self.loader,
+            metadata_path=df,
+            sample_column="sample",
+        )
         self.assertIsInstance(obj.metadata, pd.DataFrame)
         self.assertFalse(obj.metadata.empty)
 
@@ -279,6 +287,7 @@ class TestAlphaPeptDataSet(BaseTestDataSet.BaseTest):
         pd._testing.assert_frame_equal(self.obj.mat, expected_mat)
 
     def test_preprocess_normalize_linear(self):
+        # !!! normalizes by row and not by feature
         self.obj.mat = pd.DataFrame({"a": [2, 5, 4], "b": [5, 4, 4], "c": [0, 10, 8]})
         # Linear Normalization
         self.obj.preprocess(log2_transform=False, normalization="linear")
@@ -297,9 +306,9 @@ class TestAlphaPeptDataSet(BaseTestDataSet.BaseTest):
         self.obj.preprocess(log2_transform=False, normalization="vst")
         expected_mat = pd.DataFrame(
             {
-                "a": [ 3.19059101,  11.591763, 8.365096],
-                "b": [0.084829, 0.084829, 0.084829],
-                "c": [0.000000, 7.850074, 6.435102],
+                "a": [-1.307734, 1.120100, 0.187634],
+                "b": [	1.414214, -0.707107, -0.707107],
+                "c": [-1.360307, 1.015077, 0.345230],
             }
         )
         pd._testing.assert_frame_equal(self.obj.mat.round(2), expected_mat.round(2))
@@ -341,9 +350,9 @@ class TestAlphaPeptDataSet(BaseTestDataSet.BaseTest):
         self.obj.preprocess(log2_transform=False, imputation="randomforest")
         expected_mat = pd.DataFrame(
             {
-                "a": [2.00000000e00, -9.22337204e12, 4.00000000e00],
+                "a": [2.00000000e00, 0, 4.00000000e00],
                 "b": [5.00000000e00, 4.00000000e00, 4.0],
-                "c": [-9.22337204e12, 1.00000000e01, -9.22337204e12],
+                "c": [0, 1.00000000e01, 0],
             }
         )
         pd._testing.assert_frame_equal(self.obj.mat, expected_mat)
@@ -409,21 +418,23 @@ class TestMaxQuantDataSet(BaseTestDataSet.BaseTest):
                 evidence_file="testfiles/maxquant_go/evidence.txt",
             )
             DataSet(
-                loader=loader, metadata_path=self.metadata_path, sample_column="sample",
+                loader=loader,
+                metadata_path=self.metadata_path,
+                sample_column="sample",
             )
 
     def test_plot_pca_group(self):
         pca_plot = self.obj.plot_pca(group=self.comparison_column)
         # 5 different disease
         self.assertEqual(len(pca_plot.to_plotly_json().get("data")), 5)
-    
+
     def test_data_completeness(self):
         self.obj.preprocess(log2_transform=False, data_completeness=0.7)
-        self.assertEqual(self.obj.mat.shape[1], 517)
+        self.assertEqual(self.obj.mat.shape[1], 159)
 
     def test_plot_pca_circles(self):
         pca_plot = self.obj.plot_pca(group=self.comparison_column, circle=True)
-        # are there 5 circles drawn - for each group
+        # are there 5 circles test_preprocess_imputation_randomforest_values - for each group
         number_of_groups = len(pca_plot.to_plotly_json().get("layout").get("shapes"))
         self.assertEqual(number_of_groups, 5)
 
@@ -460,9 +471,7 @@ class TestMaxQuantDataSet(BaseTestDataSet.BaseTest):
             group2=["1_71_F10", "1_73_F12"],
             compare_preprocessing_modes=True,
         )
-
-        self.assertEqual(len(result_list), 12)               
-
+        self.assertEqual(len(result_list), 12)
 
     def test_preprocess_subset(self):
         self.obj.preprocess(subset=True, log2_transform=False)
@@ -488,6 +497,9 @@ class TestMaxQuantDataSet(BaseTestDataSet.BaseTest):
 
     @patch("logging.Logger.warning")
     def test_plot_intenstity_subgroup_significance_warning(self, mock):
+        import streamlit as st
+
+        st.session_state["gene_to_prot_id"] = {}
         plot = self.obj.plot_intensity(
             protein_id="K7ERI9;A0A024R0T8;P02654;K7EJI9;K7ELM9;K7EPF9;K7EKP1",
             group="disease",
@@ -535,7 +547,7 @@ class TestMaxQuantDataSet(BaseTestDataSet.BaseTest):
             draw_line=False,
         )
         n_labels = len(plot.to_plotly_json().get("layout").get("annotations"))
-        #self.assertTrue(n_labels > 20)
+        # self.assertTrue(n_labels > 20)
 
     def test_plot_volcano_wald(self):
         """
@@ -570,13 +582,15 @@ class TestMaxQuantDataSet(BaseTestDataSet.BaseTest):
 
         self.assertEqual(line_1, "spline")
         self.assertEqual(line_2, "spline")
-    
+
     def test_plot_volcano_list(self):
         self.obj.preprocess(imputation="mean")
-        plot = self.obj.plot_volcano( method="ttest",
+        plot = self.obj.plot_volcano(
+            method="ttest",
             group1=["1_31_C6", "1_32_C7", "1_57_E8"],
             group2=["1_71_F10", "1_73_F12"],
-            color_list=self.obj.mat.columns.to_list()[0:20])
+            color_list=self.obj.mat.columns.to_list()[0:20],
+        )
         self.assertEqual(len(plot.to_plotly_json()["data"][0]["x"]), 20)
 
     def test_plot_clustermap_significant(self):
@@ -602,7 +616,7 @@ class TestMaxQuantDataSet(BaseTestDataSet.BaseTest):
             labels=True,
         )
         n_labels = len(plot.to_plotly_json().get("layout").get("annotations"))
-    
+
     def test_plot_volcano_with_labels_proteins_welch_ttest(self):
         # remove gene names
         self.obj.gene_names = None
@@ -614,7 +628,7 @@ class TestMaxQuantDataSet(BaseTestDataSet.BaseTest):
             labels=True,
         )
         n_labels = len(plot.to_plotly_json().get("layout").get("annotations"))
-        #self.assertTrue(n_labels > 20)
+        # self.assertTrue(n_labels > 20)
 
     def test_calculate_diff_exp_wrong(self):
         # get groups from comparison column
@@ -711,28 +725,34 @@ class TestMaxQuantDataSet(BaseTestDataSet.BaseTest):
         self.assertEqual(annotation, "***")
 
     def test_plot_intensity_all(self):
-        plot = self.obj.plot_intensity(protein_id="Q9BWP8", 
-            group="disease", 
+        plot = self.obj.plot_intensity(
+            protein_id="Q9BWP8",
+            group="disease",
             subgroups=["liver cirrhosis", "healthy"],
             method="all",
-            add_significance=True)
+            add_significance=True,
+        )
         self.assertEqual(plot.to_plotly_json()["data"][0]["points"], "all")
 
-    
     def test_plot_samplehistograms(self):
         fig = self.obj.plot_samplehistograms().to_plotly_json()
         self.assertEqual(312, len(fig["data"]))
-    
+
     def test_batch_correction(self):
         self.obj.preprocess(subset=True, imputation="knn", normalization="quantile")
         self.obj.batch_correction(batch="batch_artifical_added")
-        first_value = self.obj.mat.values[0,0]
-        self.assertAlmostEqual(0.0111, first_value, places=2)   
+        first_value = self.obj.mat.values[0, 0]
+        self.assertAlmostEqual(0.0111, first_value, places=2)
 
     def test_multicova_analysis_invalid_covariates(self):
         self.obj.preprocess(imputation="knn", normalization="zscore", subset=True)
         res, _ = self.obj.multicova_analysis(
-            covariates=["disease", "Alkaline phosphatase measurement", "Body mass index ", "not here"],
+            covariates=[
+                "disease",
+                "Alkaline phosphatase measurement",
+                "Body mass index ",
+                "not here",
+            ],
             subset={"disease": ["healthy", "liver cirrhosis"]},
         )
         self.assertEqual(res.shape[1], 45)
@@ -743,7 +763,7 @@ class TestMaxQuantDataSet(BaseTestDataSet.BaseTest):
     #                                     group2="liver cirrhosis",
     #                                     gene_sets= 'KEGG_2019_Human')
 
-    #     cholesterol_enhanced = 'Cholesterol metabolism' in df.index.to_list()
+    #     cholersterol_enhanced = 'Cholesterol metabolism' in df.index.to_list()
     #     self.assertTrue(cholersterol_enhanced)
 
 
@@ -910,7 +930,7 @@ class TestSpectronautDataSet(BaseTestDataSet.BaseTest):
             shutil.rmtree("testfiles/spectronaut/__MACOSX")
 
         os.remove("testfiles/spectronaut/results.tsv")
-    
+
 class TestGenericDataSet(BaseTestDataSet.BaseTest):
     @classmethod
     def setUpClass(cls):
@@ -923,7 +943,7 @@ class TestGenericDataSet(BaseTestDataSet.BaseTest):
             file="testfiles/fragpipe/combined_proteins.tsv",
             intensity_column=[
                 "S1 Razor Intensity",	"S2 Razor Intensity", "S3 Razor Intensity",
-                "S4 Razor Intensity",	"S5 Razor Intensity",	"S6 Razor Intensity", 
+                "S4 Razor Intensity",	"S5 Razor Intensity",	"S6 Razor Intensity",
                 "S7 Razor Intensity", "S8 Razor Intensity"
             ],
             index_column="Protein",
@@ -935,7 +955,7 @@ class TestGenericDataSet(BaseTestDataSet.BaseTest):
             metadata_path=cls.cls_metadata_path,
             sample_column="analytical_sample external_id",
         )
-      
+
     def setUp(self):
         self.loader = copy.deepcopy(self.cls_loader)
         self.metadata_path = copy.deepcopy(self.cls_metadata_path)
@@ -949,7 +969,6 @@ class TestGenericDataSet(BaseTestDataSet.BaseTest):
         if os.path.isdir("testfiles/fragpipe/__MACOSX"):
             shutil.rmtree("testfiles/fragpipe/__MACOSX")
 
-       
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Some of the tools' output which is used in alphapeptstats use zero meaning missing data, some use NA. Previously they were not unified so the preprocessing in `_remove_na_values` was wrong. Other changes are so the downstream code can work with NAs; style, and tests.