### PR TITLE
FIX: macos release crashing because of miniconda installation

### DIFF
--- a/.github/workflows/release_on_click_installer.yml
+++ b/.github/workflows/release_on_click_installer.yml
@@ -40,6 +40,7 @@ jobs:
         uses: actions/checkout@v2
       - uses: conda-incubator/setup-miniconda@v2
         with:
+          miniconda-version: "latest"
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
       - name: Conda info
@@ -72,6 +73,7 @@ jobs:
         uses: actions/checkout@v2
       - uses: conda-incubator/setup-miniconda@v2
         with:
+          miniconda-version: "latest"
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
       - name: Conda info
@@ -104,6 +106,7 @@ jobs:
         uses: actions/checkout@v2
       - uses: conda-incubator/setup-miniconda@v2
         with:
+          miniconda-version: "latest"
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
       - name: Conda info


### PR DESCRIPTION
Update release_on_click_installer.yml