### PR TITLE
Add fix imports

### DIFF
--- a/alphastats/loader/BaseLoader.py
+++ b/alphastats/loader/BaseLoader.py
@@ -41,6 +41,7 @@ class BaseLoader:
         self.confidence_column = None
         self.software = None
         self.evidence_df = None
+        # TODO: rename to gene_names_column
         self.gene_names = None
         self.ptm_df = None
         self._add_contamination_column()

--- a/alphastats/loader/SpectronautLoader.py
+++ b/alphastats/loader/SpectronautLoader.py
@@ -38,7 +38,7 @@ class SpectronautLoader(BaseLoader):
         self.filter_columns = []
         self.evidence_df = None
 
-        columns = (
+        column_selection_regex = (
             "^"
             + "$|^".join(
                 [
@@ -51,7 +51,9 @@ class SpectronautLoader(BaseLoader):
             + "$"
         )
 
-        self.rawinput = self._read_spectronaut_file(file=file, sep=sep, columns=columns)
+        self.rawinput = self._read_spectronaut_file(
+            file=file, sep=sep, column_selection_regex=column_selection_regex
+        )
 
         if gene_names_column in self.rawinput.columns.to_list():
             self.gene_names = gene_names_column
@@ -114,7 +116,7 @@ class SpectronautLoader(BaseLoader):
         return unique_df
 
     def _read_spectronaut_file(
-        self, file: Union[str, pd.DataFrame], sep: str, columns: str
+        self, file: Union[str, pd.DataFrame], sep: str, column_selection_regex: str
     ):
         """
         Reads the Spectronaut file and converts numeric columns to float.
@@ -124,13 +126,19 @@ class SpectronautLoader(BaseLoader):
         Args:
             file (Union[str, pd.DataFrame]): path to the file or pandas.DataFrame
             sep (str): separator of the file
-            columns (str): regex pattern for columns to read
+            column_selection_regex (str): regex pattern for columns to read
 
         Returns:
             df (pd.DataFrame): Spectronaut data
         """
         if isinstance(file, pd.DataFrame):
-            df = file[[col for col in file.columns if bool(re.match(columns, col))]]
+            df = file[
+                [
+                    col
+                    for col in file.columns
+                    if bool(re.match(column_selection_regex, col))
+                ]
+            ]
             for column in df.columns:
                 try:
                     if df[column].dtype == np.float64:
@@ -144,7 +152,7 @@ class SpectronautLoader(BaseLoader):
                 file,
                 sep=sep,
                 low_memory=False,
-                usecols=lambda col: bool(re.match(columns, col)),
+                usecols=lambda col: bool(re.match(column_selection_regex, col)),
             )
             for column in df.columns:
                 try:

--- a/alphastats/loader/SpectronautLoader.py
+++ b/alphastats/loader/SpectronautLoader.py
@@ -5,6 +5,8 @@ import numpy as np
 import re
 import warnings
 
+SPECTRONAUT_COLUMN_DELIM = "."
+
 
 class SpectronautLoader(BaseLoader):
     """Loader for Spectronaut outputfiles"""
@@ -72,7 +74,9 @@ class SpectronautLoader(BaseLoader):
         if self.sample_column is not None:
             self.rawinput = self._reshape_long_to_wide()
 
-        self.intensity_column = "[sample]." + self.intensity_column
+        self.intensity_column = (
+            "[sample]" + SPECTRONAUT_COLUMN_DELIM + self.intensity_column
+        )
 
         self._add_contamination_column()
         self._read_all_columns_as_string()
@@ -83,7 +87,9 @@ class SpectronautLoader(BaseLoader):
         reshape to a wider format
         """
         self.rawinput["sample"] = (
-            self.rawinput[self.sample_column] + "." + self.intensity_column
+            self.rawinput[self.sample_column]
+            + SPECTRONAUT_COLUMN_DELIM
+            + self.intensity_column
         )
         indexing_columns = [self.index_column]
         if self.gene_names is not None:

--- a/alphastats/loader/SpectronautLoader.py
+++ b/alphastats/loader/SpectronautLoader.py
@@ -15,8 +15,6 @@ class SpectronautLoader(BaseLoader):
         index_column="PG.ProteinGroups",
         sample_column="R.FileName",
         gene_names_column="PG.Genes",
-        filter_qvalue=True,
-        qvalue_cutoff=0.01,
         sep="\t",
     ):
         """Loads Spectronaut output. Will add contamination column for further analysis.
@@ -43,9 +41,6 @@ class SpectronautLoader(BaseLoader):
         self._read_spectronaut_file(file=file, sep=sep)
 
         is_long = self._check_if_long(self.rawinput)
-
-        if filter_qvalue and is_long:
-            self._filter_qvalue(qvalue_cutoff=qvalue_cutoff)
 
         if is_long:
             self._reshape_spectronaut(
@@ -85,22 +80,6 @@ class SpectronautLoader(BaseLoader):
                 return True
             elif "PG.Quantity" in colname:
                 return False
-
-    def _filter_qvalue(self, qvalue_cutoff):
-        print(self.rawinput.columns.to_list())
-        if "EG.Qvalue" not in self.rawinput.columns.to_list():
-            raise Warning(
-                "Column EG.Qvalue not found in file. File will not be filtered according to q-value."
-            )
-
-        rows_before_filtering = self.rawinput.shape[0]
-        self.rawinput = self.rawinput[self.rawinput["EG.Qvalue"] < qvalue_cutoff]
-        rows_after_filtering = self.rawinput.shape[0]
-
-        rows_removed = rows_before_filtering - rows_after_filtering
-        logging.info(
-            f"{rows_removed} identification with a qvalue below {qvalue_cutoff} have been removed"
-        )
 
     def _read_spectronaut_file(self, file, sep):
         # some spectronaut files include european decimal separators

--- a/tests/test_DataSet.py
+++ b/tests/test_DataSet.py
@@ -929,9 +929,7 @@ class TestSpectronautDataSet(BaseTestDataSet.BaseTest):
                 "testfiles/spectronaut/results.tsv.zip", "testfiles/spectronaut/"
             )
 
-        cls.cls_loader = SpectronautLoader(
-            file="testfiles/spectronaut/results.tsv", filter_qvalue=False
-        )
+        cls.cls_loader = SpectronautLoader(file="testfiles/spectronaut/results.tsv")
         cls.cls_metadata_path = "testfiles/spectronaut/metadata.xlsx"
         cls.cls_obj = DataSet(
             loader=cls.cls_loader,

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -208,9 +208,7 @@ class TestSpectronautLoader(BaseTestLoader.BaseTest):
                 "testfiles/spectronaut/results.tsv.zip", "testfiles/spectronaut/"
             )
 
-        cls.obj = SpectronautLoader(
-            file="testfiles/spectronaut/results.tsv", filter_qvalue=False
-        )
+        cls.obj = SpectronautLoader(file="testfiles/spectronaut/results.tsv")
         cls.df_dim = (2458, 11)
 
     def test_reading_non_european_comma(self):
@@ -219,30 +217,15 @@ class TestSpectronautLoader(BaseTestLoader.BaseTest):
         """
         s = SpectronautLoader(
             file="testfiles/spectronaut/results_non_european_comma.tsv",
-            filter_qvalue=False,
         )
         mean = s.rawinput[
             "20221015_EV_TP_40SPD_LITDIA_MS1_Rapid_MS2_Rapid_57w_100ng_03_PG.Quantity"
         ].mean()
 
-    def test_qvalue_filtering(self):
-        obj = SpectronautLoader(
-            file="testfiles/spectronaut/results.tsv",
-            filter_qvalue=True,
-            qvalue_cutoff=0.00000001,
-        )
-        self.assertEqual(obj.rawinput.shape, (2071, 10))
-
-    def test_qvalue_filtering_warning(self):
-        with self.assertRaises(Warning):
-            df = pd.read_csv("testfiles/spectronaut/results.tsv", sep="\t", decimal=",")
-            df.drop(columns=["EG.Qvalue"], axis=1, inplace=True)
-            SpectronautLoader(file=df)
-
     def test_gene_name_column(self):
         df = pd.read_csv("testfiles/spectronaut/results.tsv", sep="\t", decimal=",")
         df["PG.Genes"] = 0
-        s = SpectronautLoader(file=df, filter_qvalue=False)
+        s = SpectronautLoader(file=df)
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -219,7 +219,7 @@ class TestSpectronautLoader(BaseTestLoader.BaseTest):
             file="testfiles/spectronaut/results_non_european_comma.tsv",
         )
         mean = s.rawinput[
-            "20221015_EV_TP_40SPD_LITDIA_MS1_Rapid_MS2_Rapid_57w_100ng_03_PG.Quantity"
+            "20221015_EV_TP_40SPD_LITDIA_MS1_Rapid_MS2_Rapid_57w_100ng_03.PG.Quantity"
         ].mean()
 
     def test_gene_name_column(self):


### PR DESCRIPTION
This is fixing the Spectronaut loader, which already had functionality for switching between long and wide format, but didn't handle the wide format in any way.

Columns read are now already reduced at read_csv by usecols.

Data deduplication (necessary because of potential EG. and PEP. columns in the output) is now decoupled from reshaping.