### PR TITLE
BUGFIX: remove additions before log transform

### DIFF
--- a/alphastats/DataSet_Preprocess.py
+++ b/alphastats/DataSet_Preprocess.py
@@ -250,7 +250,7 @@ class Preprocess:
         return results_list
 
     def _log2_transform(self):
-        self.mat = np.log2(self.mat + 0.1)
+        self.mat = np.log2(self.mat)
         self.preprocessing_info.update({"Log2-transformed": True})
         print("Data has been log2-transformed.")
 

--- a/alphastats/DataSet_Statistics.py
+++ b/alphastats/DataSet_Statistics.py
@@ -15,9 +15,9 @@ from alphastats.statistics.Anova import Anova
 
 
 class Statistics:
-    def _calculate_foldchange(self, mat_transpose:pd.DataFrame, group1_samples:list, group2_samples:list) -> pd.DataFrame:
-        mat_transpose += 0.00001
-
+    def _calculate_foldchange(
+        self, mat_transpose: pd.DataFrame, group1_samples: list, group2_samples: list
+    ) -> pd.DataFrame:
         if self.preprocessing_info["Log2-transformed"]:
             fc = (
                 mat_transpose[group1_samples].T.mean().values

--- a/alphastats/plots/VolcanoPlot.py
+++ b/alphastats/plots/VolcanoPlot.py
@@ -149,7 +149,7 @@ class VolcanoPlot(PlotUtils):
 
         transposed = self.dataset.mat.transpose()
 
-        if self.dataset.preprocessing_info["Normalization"] is None:
+        if self.dataset.preprocessing_info["Log2-transformed"] is None:
             # needs to be lpog2 transformed for fold change calculations
             transposed = transposed.transform(lambda x: np.log2(x))
 

--- a/alphastats/statistics/DifferentialExpressionAnalysis.py
+++ b/alphastats/statistics/DifferentialExpressionAnalysis.py
@@ -90,7 +90,7 @@ class DifferentialExpressionAnalysis:
         from alphastats.multicova import multicova
         transposed = self.dataset.mat.transpose()
 
-        if self.dataset.preprocessing_info["Normalization"] is None:
+        if self.dataset.preprocessing_info["Log2-transformed"] is None:
             # needs to be lpog2 transformed for fold change calculations
             transposed = transposed.transform(lambda x: np.log2(x))
 
@@ -190,9 +190,9 @@ class DifferentialExpressionAnalysis:
         df["log2fc"] = fc
         return df
 
-    def _calculate_foldchange(self, mat_transpose:pd.DataFrame, group1_samples:list, group2_samples:list):
-        mat_transpose += 0.00001
-
+    def _calculate_foldchange(
+        self, mat_transpose: pd.DataFrame, group1_samples: list, group2_samples: list
+    ):
         if self.dataset.preprocessing_info["Log2-transformed"]:
             fc = (
                 mat_transpose[group1_samples].T.mean().values


### PR DESCRIPTION
This caused a bug in all data processing that followed the log transformation operation in preprocessing or statistical tests based on fold change calculation.

Also, fixes wrong behaviour if normalization is used