### PR TITLE
Remove index column

### DIFF
--- a/alphastats/DataSet.py
+++ b/alphastats/DataSet.py
@@ -3,10 +3,10 @@ from typing import Dict, List, Optional, Tuple, Union
 import pandas as pd
 import plotly
 import scipy
-from dataset_harmonizer import DataHarmonizer
 
 from alphastats import BaseLoader
 from alphastats.dataset_factory import DataSetFactory
+from alphastats.dataset_harmonizer import DataHarmonizer
 from alphastats.DataSet_Plot import Plot
 from alphastats.DataSet_Preprocess import Preprocess
 from alphastats.DataSet_Statistics import Statistics

--- a/alphastats/DataSet.py
+++ b/alphastats/DataSet.py
@@ -3,6 +3,7 @@ from typing import Dict, List, Optional, Tuple, Union
 import pandas as pd
 import plotly
 import scipy
+from dataset_harmonizer import DataHarmonizer
 
 from alphastats import BaseLoader
 from alphastats.dataset_factory import DataSetFactory
@@ -64,9 +65,7 @@ class DataSet:
         self._check_loader(loader=loader)
 
         # fill data from loader
-        self.rawinput: pd.DataFrame = loader.rawinput.rename(
-            columns={loader.index_column: Cols.INDEX}
-        )
+        self.rawinput: pd.DataFrame = DataHarmonizer(loader).get_rawinput()
         self.filter_columns: List[str] = loader.filter_columns
 
         self.software: str = loader.software

--- a/alphastats/DataSet.py
+++ b/alphastats/DataSet.py
@@ -9,6 +9,7 @@ from alphastats.dataset_factory import DataSetFactory
 from alphastats.DataSet_Plot import Plot
 from alphastats.DataSet_Preprocess import Preprocess
 from alphastats.DataSet_Statistics import Statistics
+from alphastats.keys import Cols
 from alphastats.plots.ClusterMap import ClusterMap
 from alphastats.plots.DimensionalityReduction import DimensionalityReduction
 from alphastats.plots.IntensityPlot import IntensityPlot
@@ -63,9 +64,11 @@ class DataSet:
         self._check_loader(loader=loader)
 
         # fill data from loader
-        self.rawinput: pd.DataFrame = loader.rawinput
+        self.rawinput: pd.DataFrame = loader.rawinput.rename(
+            columns={loader.index_column: Cols.INDEX}
+        )
         self.filter_columns: List[str] = loader.filter_columns
-        self.index_column: str = loader.index_column
+
         self.software: str = loader.software
         self._gene_names: str = loader.gene_names
 
@@ -81,7 +84,6 @@ class DataSet:
 
         self._dataset_factory = DataSetFactory(
             rawinput=self.rawinput,
-            index_column=self.index_column,
             intensity_column=self._intensity_column,
             metadata_path_or_df=metadata_path_or_df,
             sample_column=sample_column,
@@ -100,7 +102,7 @@ class DataSet:
                 for k, v in dict(
                     zip(
                         self.rawinput[self._gene_names].tolist(),
-                        self.rawinput[self.index_column].tolist(),
+                        self.rawinput[Cols.INDEX].tolist(),
                     )
                 ).items()
                 if isinstance(k, str)  # avoid having NaN as key
@@ -155,7 +157,6 @@ class DataSet:
         return Preprocess(
             self.filter_columns,
             self.rawinput,
-            self.index_column,
             self.sample,
             self.metadata,
             self.preprocessing_info,
@@ -206,7 +207,6 @@ class DataSet:
         return Statistics(
             mat=self.mat,
             metadata=self.metadata,
-            index_column=self.index_column,
             sample=self.sample,
             preprocessing_info=self.preprocessing_info,
         )
@@ -239,7 +239,6 @@ class DataSet:
             df,
             protein_id,
             group,
-            self.index_column,
         )
 
     def anova(self, column: str, protein_ids="all", tukey: bool = True) -> pd.DataFrame:
@@ -400,7 +399,6 @@ class DataSet:
             rawinput=self.rawinput,
             metadata=self.metadata,
             sample=self.sample,
-            index_column=self.index_column,
             gene_names=self._gene_names,
             preprocessing_info=self.preprocessing_info,
             group1=group1,
@@ -523,7 +521,6 @@ class DataSet:
             mat=self.mat,
             metadata=self.metadata,
             sample=self.sample,
-            index_column=self.index_column,
             preprocessing_info=self.preprocessing_info,
             label_bar=label_bar,
             only_significant=only_significant,

--- a/alphastats/DataSet.py
+++ b/alphastats/DataSet.py
@@ -65,7 +65,9 @@ class DataSet:
         self._check_loader(loader=loader)
 
         # fill data from loader
-        self.rawinput: pd.DataFrame = DataHarmonizer(loader).get_rawinput()
+        self.rawinput: pd.DataFrame = DataHarmonizer(loader).get_harmonized_rawinput(
+            loader.rawinput
+        )
         self.filter_columns: List[str] = loader.filter_columns
 
         self.software: str = loader.software

--- a/alphastats/DataSet_Preprocess.py
+++ b/alphastats/DataSet_Preprocess.py
@@ -9,6 +9,7 @@ import sklearn.impute
 import streamlit as st
 from sklearn.experimental import enable_iterative_imputer  # noqa
 
+from alphastats.keys import Cols
 from alphastats.utils import ignore_warning
 
 
@@ -45,7 +46,6 @@ class Preprocess:
         self,
         filter_columns: List[str],
         rawinput: pd.DataFrame,
-        index_column: str,
         sample: str,
         metadata: pd.DataFrame,
         preprocessing_info: Dict,
@@ -54,7 +54,6 @@ class Preprocess:
         self.filter_columns = filter_columns
 
         self.rawinput = rawinput
-        self.index_column = index_column
         self.sample = sample
 
         self.metadata = metadata
@@ -157,7 +156,7 @@ class Preprocess:
         # print column names with contamination
         protein_groups_to_remove = self.rawinput[
             self.rawinput[self.filter_columns].any(axis=1)
-        ][self.index_column].tolist()
+        ][Cols.INDEX].tolist()
 
         protein_groups_to_remove = list(
             set(protein_groups_to_remove) & set(self.mat.columns.to_list())

--- a/alphastats/DataSet_Statistics.py
+++ b/alphastats/DataSet_Statistics.py
@@ -17,13 +17,11 @@ class Statistics:
         *,
         mat: pd.DataFrame,
         metadata: pd.DataFrame,
-        index_column: str,
         sample: str,
         preprocessing_info: Dict,
     ):
         self.mat: pd.DataFrame = mat
         self.metadata: pd.DataFrame = metadata
-        self.index_column: str = index_column
         self.sample: str = sample
         self.preprocessing_info: Dict = preprocessing_info
 
@@ -62,7 +60,6 @@ class Statistics:
         df = DifferentialExpressionAnalysis(
             mat=self.mat,
             metadata=self.metadata,
-            index_column=self.index_column,
             sample=self.sample,
             preprocessing_info=self.preprocessing_info,
             group1=group1,
@@ -93,7 +90,6 @@ class Statistics:
             mat=self.mat,
             metadata=self.metadata,
             sample=self.sample,
-            index_column=self.index_column,
             column=column,
             protein_ids=protein_ids,
             tukey=tukey,

--- a/alphastats/dataset_factory.py
+++ b/alphastats/dataset_factory.py
@@ -5,6 +5,8 @@ from typing import List, Optional, Tuple, Union
 import numpy as np
 import pandas as pd
 
+from alphastats.keys import Cols
+
 
 class DataSetFactory:
     """Create all 'heavy' data structures of a DataSet."""
@@ -13,14 +15,12 @@ class DataSetFactory:
         self,
         *,
         rawinput: pd.DataFrame,
-        index_column: str,
         intensity_column: Union[List[str], str],
         metadata_path_or_df: Union[str, pd.DataFrame],
         sample_column: str,
     ):
         self.rawinput: pd.DataFrame = rawinput
         self.sample_column: str = sample_column
-        self.index_column: str = index_column
         self.intensity_column: Union[List[str], str] = intensity_column
         self.metadata_path_or_df: Union[str, pd.DataFrame] = metadata_path_or_df
 
@@ -28,7 +28,7 @@ class DataSetFactory:
         """Creates a matrix: features (Proteins) as columns, samples as rows."""
 
         df = self.rawinput
-        df = df.set_index(self.index_column)
+        df = df.set_index(Cols.INDEX)
 
         if isinstance(self.intensity_column, str):
             regex_find_intensity_columns = self.intensity_column.replace(

--- a/alphastats/dataset_harmonizer.py
+++ b/alphastats/dataset_harmonizer.py
@@ -1,0 +1,26 @@
+"""Harmonize the input data to a common format."""
+
+import pandas as pd
+from keys import Cols
+
+from alphastats import BaseLoader
+
+
+class DataHarmonizer:
+    """Harmonize input data to a common format."""
+
+    def __init__(self, loader: BaseLoader):
+        self._rawinput = loader.rawinput
+        self._index_column = loader.index_column
+
+    def get_rawinput(self) -> pd.DataFrame:
+        """Harmonize the rawinput data to a common format."""
+        if Cols.INDEX in self._rawinput.columns:
+            raise ValueError(
+                f"Column name {Cols.INDEX} already exists in rawinput. Please rename the column."
+            )
+
+        return self._rawinput.rename(
+            columns={self._index_column: Cols.INDEX},
+            errors="raise",
+        )

--- a/alphastats/dataset_harmonizer.py
+++ b/alphastats/dataset_harmonizer.py
@@ -10,17 +10,17 @@ class DataHarmonizer:
     """Harmonize input data to a common format."""
 
     def __init__(self, loader: BaseLoader):
-        self._rawinput = loader.rawinput
-        self._index_column = loader.index_column
+        self._rename_dict = {loader.index_column: Cols.INDEX}
 
-    def get_rawinput(self) -> pd.DataFrame:
+    def get_harmonized_rawinput(self, rawinput: pd.DataFrame) -> pd.DataFrame:
         """Harmonize the rawinput data to a common format."""
-        if Cols.INDEX in self._rawinput.columns:
-            raise ValueError(
-                f"Column name {Cols.INDEX} already exists in rawinput. Please rename the column."
-            )
+        for target_name in self._rename_dict.values():
+            if target_name in rawinput.columns:
+                raise ValueError(
+                    f"Column name {target_name} already exists in rawinput. Please rename the column."
+                )
 
-        return self._rawinput.rename(
-            columns={self._index_column: Cols.INDEX},
+        return rawinput.rename(
+            columns=self._rename_dict,
             errors="raise",
         )

--- a/alphastats/dataset_harmonizer.py
+++ b/alphastats/dataset_harmonizer.py
@@ -1,9 +1,9 @@
 """Harmonize the input data to a common format."""
 
 import pandas as pd
-from keys import Cols
 
 from alphastats import BaseLoader
+from alphastats.keys import Cols
 
 
 class DataHarmonizer:

--- a/alphastats/gui/utils/analysis_helper.py
+++ b/alphastats/gui/utils/analysis_helper.py
@@ -166,7 +166,6 @@ def gui_volcano_plot() -> Tuple[Optional[Any], Optional[Any], Optional[Dict]]:
             rawinput=dataset.rawinput,
             metadata=dataset.metadata,
             sample=dataset.sample,
-            index_column=dataset.index_column,
             gene_names=dataset._gene_names,
             preprocessing_info=dataset.preprocessing_info,
             **parameters,

--- a/alphastats/gui/utils/import_helper.py
+++ b/alphastats/gui/utils/import_helper.py
@@ -132,6 +132,7 @@ def _check_softwarefile_df(df: pd.DataFrame, software: str) -> None:
 
     Can be fragile when different settings are used or software is updated.
     """
+    # TODO this needs to go to the loader
 
     if software == "MaxQuant":
         expected_columns = ["Protein IDs", "Reverse", "Potential contaminant"]
@@ -241,7 +242,9 @@ def get_sample_names_from_software_file(loader: BaseLoader) -> List[str]:
     """
     extract sample names from software
     """
-    if isinstance(loader.intensity_column, str):
+    if isinstance(
+        loader.intensity_column, str
+    ):  # TODO duplicated logic in MaxQuantLoader
         regex_find_intensity_columns = loader.intensity_column.replace("[sample]", ".*")
         df = loader.rawinput
         df = df.set_index(loader.index_column)

--- a/alphastats/keys.py
+++ b/alphastats/keys.py
@@ -1,0 +1,7 @@
+"""String constants for accessing columns."""
+
+
+class Cols:
+    """String constants for accessing columns of the main dataframe in DataSet."""
+
+    INDEX = "index_"

--- a/alphastats/multicova/multicova.py
+++ b/alphastats/multicova/multicova.py
@@ -354,8 +354,6 @@ def perform_ttest_analysis(
     s0=1,
     n_perm=2,
     fdr=0.01,
-    id_col="Genes",
-    plot_fdr_line=False,
     parallelize=False,
 ):
     """

--- a/alphastats/plots/ClusterMap.py
+++ b/alphastats/plots/ClusterMap.py
@@ -5,6 +5,7 @@ import pandas as pd
 import seaborn as sns
 
 from alphastats.DataSet_Statistics import Statistics
+from alphastats.keys import Cols
 from alphastats.plots.PlotUtils import PlotUtils
 
 
@@ -15,7 +16,6 @@ class ClusterMap(PlotUtils):
         mat: pd.DataFrame,
         metadata: pd.DataFrame,
         sample: str,
-        index_column: str,
         preprocessing_info: Dict,
         label_bar,
         only_significant,
@@ -25,13 +25,11 @@ class ClusterMap(PlotUtils):
         self.mat: pd.DataFrame = mat
         self.metadata: pd.DataFrame = metadata
         self.sample: str = sample
-        self.index_column: str = index_column
         self.preprocessing_info: Dict = preprocessing_info
 
         self._statistics = Statistics(
             mat=self.mat,
             metadata=self.metadata,
-            index_column=self.index_column,
             sample=self.sample,
             preprocessing_info=self.preprocessing_info,
         )
@@ -61,7 +59,7 @@ class ClusterMap(PlotUtils):
         if self.only_significant and self.group is not None:
             anova_df = self._statistics.anova(column=self.group, tukey=False)
             significant_proteins = anova_df[anova_df["ANOVA_pvalue"] < 0.05][
-                self.index_column
+                Cols.INDEX
             ].to_list()
             df = df[significant_proteins]  # TODO bug?
 

--- a/alphastats/statistics/Anova.py
+++ b/alphastats/statistics/Anova.py
@@ -4,6 +4,7 @@ import pandas as pd
 import scipy
 from tqdm import tqdm
 
+from alphastats.keys import Cols
 from alphastats.statistics.tukey_test import tukey_test
 
 
@@ -13,7 +14,6 @@ class Anova:
         mat: pd.DataFrame,
         metadata: pd.DataFrame,
         sample: str,
-        index_column: str,
         column: str,
         protein_ids: Union[str, List[str]],
         tukey: bool,
@@ -21,7 +21,6 @@ class Anova:
         self.mat: pd.DataFrame = mat
         self.metadata: pd.DataFrame = metadata
         self.sample: str = sample
-        self.index_column: str = index_column
 
         # TODO move these to perform()?
         self.column: str = column
@@ -47,7 +46,7 @@ class Anova:
             axis=1,
         )
         anova_df = pd.DataFrame()
-        anova_df[self.index_column], anova_df["ANOVA_pvalue"] = (
+        anova_df[Cols.INDEX], anova_df["ANOVA_pvalue"] = (
             p_values.index.tolist(),
             p_values.values,
         )
@@ -80,19 +79,18 @@ class Anova:
                     df=df,
                     protein_id=protein_id,
                     group=self.column,
-                    index_column=self.index_column,
                 )
             )
         # combine all tukey test results
         tukey_df = pd.concat(tukey_df_list)
         # combine anova and tukey test results
         final_df = anova_df.merge(
-            tukey_df[["comparison", "p-tukey", self.index_column]],
+            tukey_df[["comparison", "p-tukey", Cols.INDEX]],
             how="inner",
-            on=[self.index_column],
+            on=[Cols.INDEX],
         )
         final_df = final_df.pivot(
-            index=[self.index_column, "ANOVA_pvalue"],
+            index=[Cols.INDEX, "ANOVA_pvalue"],
             columns=["comparison"],
             values="p-tukey",
         )

--- a/alphastats/statistics/MultiCovaAnalysis.py
+++ b/alphastats/statistics/MultiCovaAnalysis.py
@@ -3,10 +3,11 @@ import warnings
 import numpy as np
 import plotly.express as px
 
-from alphastats.statistics.StatisticUtils import StatisticUtils
+from alphastats.keys import Cols
 
 
-class MultiCovaAnalysis(StatisticUtils):
+# TODO unused
+class MultiCovaAnalysis:
     def __init__(
         self,
         dataset,
@@ -17,7 +18,7 @@ class MultiCovaAnalysis(StatisticUtils):
         subset: dict = None,
         plot: bool = False,
     ):
-        self.dataset = dataset
+        self.dataset = dataset  # TODO pass only .mat, .metadata and .sample
         self.covariates = covariates
         self.n_permutations = n_permutations
         self.fdr = fdr
@@ -98,7 +99,7 @@ class MultiCovaAnalysis(StatisticUtils):
 
     def _prepare_matrix(self):
         transposed = self.dataset.mat.transpose()
-        transposed[self.dataset.index_column] = transposed.index
+        transposed[Cols.INDEX] = transposed.index
         transposed = transposed.reset_index(drop=True)
         self.transposed = transposed[self.metadata[self.dataset.sample].to_list()]
 
@@ -111,7 +112,7 @@ class MultiCovaAnalysis(StatisticUtils):
             y=-np.log10(res_real[variable + "_" + "pval"]),
             color=res_real[sig_col],
             color_discrete_map={"sig": "#009599", "non_sig": "#404040"},
-            hover_name=res_real[self.dataset.index_column],
+            hover_name=res_real[Cols.INDEX],
             title=variable,
             labels=dict(x="beta value", y="-log10(p-value)", color=sig_level),
         )
@@ -134,7 +135,7 @@ class MultiCovaAnalysis(StatisticUtils):
             fdr=self.fdr,
             s0=self.s0,
         )
-        res[self.dataset.index_column] = self.dataset.mat.columns.to_list()
+        res[Cols.INDEX] = self.dataset.mat.columns.to_list()
         plot_list = []
 
         if self.plot:

--- a/alphastats/statistics/tukey_test.py
+++ b/alphastats/statistics/tukey_test.py
@@ -1,12 +1,13 @@
 import pandas as pd
 import pingouin
 
+from alphastats.keys import Cols
+
 
 def tukey_test(
     df: pd.DataFrame,
     protein_id: str,
     group: str,
-    index_column: str,
 ) -> pd.DataFrame:
     """Calculate Pairwise Tukey-HSD post-hoc test
     Wrapper around:
@@ -35,7 +36,7 @@ def tukey_test(
     try:
         tukey_df = pingouin.pairwise_tukey(data=df, dv=protein_id, between=group)
         tukey_df["comparison"] = tukey_df["A"] + " vs. " + tukey_df["B"] + " Tukey Test"
-        tukey_df[index_column] = protein_id
+        tukey_df[Cols.INDEX] = protein_id
 
     except ValueError:
         tukey_df = pd.DataFrame()

--- a/tests/gui/test_02_import_data.py
+++ b/tests/gui/test_02_import_data.py
@@ -110,7 +110,6 @@ def test_page_02_loads_maxquant_testfiles(
 
     dataset = at.session_state[StateKeys.DATASET]
     assert dataset._gene_names == "Gene names"
-    assert dataset.index_column == "Protein IDs"
     assert dataset._intensity_column == "LFQ intensity [sample]"
     assert dataset.rawmat.shape == (312, 2611)
     assert dataset.software == "MaxQuant"


### PR DESCRIPTION
harmonize the input data w.r.t "index_column" to be able to rely on a fixed value throughout the codebase to reduce clutter and passing around arguments.

Will do the same for "gene_names" and "sample" columns.

The only downside is that the internal name is now shown at these places (could be fixed, but a little effort):
![image](https://github.com/user-attachments/assets/8b675380-32b0-49c7-a411-d61a4c89f6a7)

![image](https://github.com/user-attachments/assets/32c2d5e7-884d-4419-9071-da1f5c3f7d9b)
