### PR TITLE
Annotation retrieval and textualization

### DIFF
--- a/alphastats/gui/pages/05_Analysis.py
+++ b/alphastats/gui/pages/05_Analysis.py
@@ -1,9 +1,11 @@
 import streamlit as st
 
+from alphastats.dataset.keys import Cols
 from alphastats.gui.utils.analysis import PlottingOptions, StatisticOptions
 from alphastats.gui.utils.analysis_helper import (
     display_analysis_result_with_buttons,
     gather_parameters_and_do_analysis,
+    gather_uniprot_data,
 )
 from alphastats.gui.utils.ui_helper import (
     StateKeys,
@@ -92,6 +94,15 @@ def show_start_llm_button(analysis_method: str) -> None:
         if StateKeys.LLM_INTEGRATION in st.session_state:
             del st.session_state[StateKeys.LLM_INTEGRATION]
         st.session_state[StateKeys.LLM_INPUT] = (analysis_object, parameters)
+        with st.spinner("Retrieving uniprot data on regulated features ..."):
+            regulated_features = [
+                feature
+                for feature, label in zip(
+                    analysis_object.res[Cols.INDEX], analysis_object.res["label"]
+                )
+                if label != ""
+            ]
+            gather_uniprot_data(regulated_features)
 
         st.toast("LLM analysis created!", icon="✅")
         st.page_link("pages/06_LLM.py", label="=> Go to LLM page..")

--- a/alphastats/gui/pages/06_LLM.py
+++ b/alphastats/gui/pages/06_LLM.py
@@ -17,6 +17,7 @@ from alphastats.gui.utils.llm_helper import (
 from alphastats.gui.utils.ui_helper import StateKeys, init_session_state, sidebar_info
 from alphastats.llm.llm_integration import LLMIntegration, Models
 from alphastats.llm.prompts import get_initial_prompt, get_system_message
+from alphastats.llm.uniprot_utils import ExtractedFields, format_uniprot_information
 from alphastats.plots.plot_utils import PlotlyObject
 
 OLLAMA_BASE_URL = os.getenv("OLLAMA_BASE_URL", "http://localhost:11434")
@@ -131,8 +132,23 @@ with c1:
             unsafe_allow_html=True,
         )
 
-with st.expander("Retrieved uniprot data"):
-    st.json(st.session_state[StateKeys.ANNOTATION_STORE])
+with st.expander("Available uniprot data"):
+    text_repr = {}
+    for feature in list(regulated_genes_dict.keys()):
+        try:
+            text_repr[
+                st.session_state[StateKeys.DATASET]._feature_to_repr_map[feature]
+            ] = {
+                "protein ids": feature,
+                "text": format_uniprot_information(
+                    st.session_state[StateKeys.ANNOTATION_STORE][feature],
+                    fields=ExtractedFields.get_values(),
+                ),
+            }
+        except Exception as e:
+            st.markdown(feature)
+            st.markdown(e)
+    st.json(text_repr, expanded=False)
 
 
 st.markdown("##### Prompts generated based on analysis input")

--- a/alphastats/gui/pages/06_LLM.py
+++ b/alphastats/gui/pages/06_LLM.py
@@ -4,6 +4,7 @@ import pandas as pd
 import streamlit as st
 from openai import AuthenticationError
 
+from alphastats.dataset.keys import Cols
 from alphastats.dataset.plotting import plotly_object
 from alphastats.gui.utils.analysis_helper import (
     display_figure,
@@ -101,7 +102,7 @@ with c2:
 with c1:
     regulated_genes_df = volcano_plot.res[volcano_plot.res["label"] != ""]
     regulated_genes_dict = dict(
-        zip(regulated_genes_df["label"], regulated_genes_df["color"].tolist())
+        zip(regulated_genes_df[Cols.INDEX], regulated_genes_df["color"].tolist())
     )
 
     if not regulated_genes_dict:

--- a/alphastats/gui/pages/06_LLM.py
+++ b/alphastats/gui/pages/06_LLM.py
@@ -130,6 +130,9 @@ with c1:
             unsafe_allow_html=True,
         )
 
+with st.expander("Retrieved uniprot data"):
+    st.json(st.session_state[StateKeys.ANNOTATION_STORE])
+
 
 st.markdown("##### Prompts generated based on analysis input")
 

--- a/alphastats/gui/utils/analysis_helper.py
+++ b/alphastats/gui/utils/analysis_helper.py
@@ -13,6 +13,7 @@ from alphastats.gui.utils.ui_helper import (
     StateKeys,
     show_button_download_df,
 )
+from alphastats.llm.uniprot_utils import get_information_for_feature
 from alphastats.plots.plot_utils import PlotlyObject
 
 
@@ -197,3 +198,12 @@ def gather_parameters_and_do_analysis(
 
     else:
         raise ValueError(f"Analysis method {analysis_method} not found.")
+
+
+def gather_uniprot_data(features: list):
+    for feature in features:
+        if feature in st.session_state[StateKeys.ANNOTATION_STORE]:
+            continue
+        st.session_state[StateKeys.ANNOTATION_STORE][feature] = (
+            get_information_for_feature(feature, all_fields=True)
+        )

--- a/alphastats/gui/utils/analysis_helper.py
+++ b/alphastats/gui/utils/analysis_helper.py
@@ -205,5 +205,5 @@ def gather_uniprot_data(features: list):
         if feature in st.session_state[StateKeys.ANNOTATION_STORE]:
             continue
         st.session_state[StateKeys.ANNOTATION_STORE][feature] = (
-            get_information_for_feature(feature, all_fields=True)
+            get_information_for_feature(feature)
         )

--- a/alphastats/gui/utils/llm_helper.py
+++ b/alphastats/gui/utils/llm_helper.py
@@ -16,11 +16,11 @@ def get_display_proteins_html(protein_ids: List[str], is_upregulated: True) -> s
         is_upregulated (bool): whether the proteins are up- or down-regulated.
     """
 
-    uniprot_url = "https://www.uniprot.org/uniprotkb?query="
+    uniprot_url = "https://www.uniprot.org/uniprotkb/"
 
     color = "green" if is_upregulated else "red"
     protein_ids_html = "".join(
-        f'<a href = {uniprot_url + protein}><li style="color: {color};">{protein}</li></a>'
+        f'<a href = {uniprot_url + st.session_state[StateKeys.ANNOTATION_STORE][protein].get("primaryAccession",protein)}><li style="color: {color};">{st.session_state[StateKeys.DATASET]._feature_to_repr_map[protein]}</li></a>'
         for protein in protein_ids
     )
 

--- a/alphastats/gui/utils/ui_helper.py
+++ b/alphastats/gui/utils/ui_helper.py
@@ -118,6 +118,9 @@ def init_session_state() -> None:
     if StateKeys.LLM_INTEGRATION not in st.session_state:
         st.session_state[StateKeys.LLM_INTEGRATION] = {}
 
+    if StateKeys.ANNOTATION_STORE not in st.session_state:
+        st.session_state[StateKeys.ANNOTATION_STORE] = {}
+
 
 class StateKeys(metaclass=ConstantsClass):
     USER_SESSION_ID = "user_session_id"
@@ -132,5 +135,6 @@ class StateKeys(metaclass=ConstantsClass):
     MODEL_NAME = "model_name"
     LLM_INPUT = "llm_input"
     LLM_INTEGRATION = "llm_integration"
+    ANNOTATION_STORE = "annotation_store"
 
     ORGANISM = "organism"  # TODO this is essentially a constant

--- a/tests/llm/test_llm_helper.py
+++ b/tests/llm/test_llm_helper.py
@@ -33,9 +33,9 @@ def test_display_proteins_upregulated(mock_streamlit):
     result = get_display_proteins_html(protein_ids, is_upregulated=True)
 
     expected_html = (
-        "<ul><a href = https://www.uniprot.org/uniprotkb?query=P12345>"
+        "<ul><a href = https://www.uniprot.org/uniprotkb/P12345>"
         + '<li style="color: green;">P12345</li></a>'
-        + "<a href = https://www.uniprot.org/uniprotkb?query=Q67890>"
+        + "<a href = https://www.uniprot.org/uniprotkb/Q67890>"
         + '<li style="color: green;">Q67890</li></a></ul>'
     )
 
@@ -48,7 +48,7 @@ def test_display_proteins_downregulated(mock_streamlit):
     result = get_display_proteins_html(protein_ids, is_upregulated=False)
 
     expected_html = (
-        "<ul><a href = https://www.uniprot.org/uniprotkb?query=P12345>"
+        "<ul><a href = https://www.uniprot.org/uniprotkb/P12345>"
         + '<li style="color: red;">P12345</li></a></ul>'
     )
 

--- a/tests/test_gpt.py
+++ b/tests/test_gpt.py
@@ -223,19 +223,20 @@ class TestExtractData(unittest.TestCase):
         self.assertEqual(result["tissueSpecificity"], expected_tissue_specificity)
 
         # Verify cross references extraction
-        expected_pathways = [
+        expected_GOP = [
             {
-                "database": "GO Pathway",
                 "id": "ABC123",
-                "pathway": "some pathway",
-            },
+                "name": "some pathway",
+            }
+        ]
+        self.assertEqual(result["GO Pathway"], expected_GOP)
+        expected_reactome = [
             {
-                "database": "Reactome",
                 "id": "ABC1234",
-                "pathway": "some pathway",
+                "name": "some pathway",
             },
         ]
-        self.assertEqual(result["pathway_references"], expected_pathways)
+        self.assertEqual(result["Reactome"], expected_reactome)
 
 
 class TestSelectID(unittest.TestCase):


### PR DESCRIPTION
Introducing the annotation store, that holds all the info grabbed from uniprot during a session for any feature.

Also introducing puzzling together the information into a string that can be fed to the LLM.

Next step would be to introduce a checkbox list to select which fields to actually use and feed that to the LLM.

I still need to write/fix tests but feel free to comment besides that already.