### PR TITLE
add stricter linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,15 @@ repos:
     - id: ruff-format
     - id: ruff
       args: ['--fix']
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.8.6 # newer version -> stricter
+  hooks:
+    - id: ruff
+      # running ruff again with rules in ruff-lint-psm-readers.toml (specific files, all rules)
+      args:
+        - "--config"
+        - "ruff-lint-strict.toml"
+        - "--fix"
 -   repo: https://github.com/Yelp/detect-secrets
     rev: v1.5.0
     hooks:

--- a/ruff-lint-strict.toml
+++ b/ruff-lint-strict.toml
@@ -1,0 +1,66 @@
+# specific ruff configuraton new code (with stricter rules)
+[lint]
+select = [
+    "ALL"
+]
+
+# TODO excluding explicity is not great but it is a workaround for now
+exclude = [
+    "setup.py",
+    "alphastats/__*__.py",
+    "alphastats/tl/*.py",
+    "alphastats/pl/*.py",
+    "alphastats/cli.py",
+    "alphastats/data/*.py",
+    "alphastats/dataset/*.py",
+    "alphastats/llm/*.py",
+    "alphastats/loader/*.py",
+    "alphastats/multicova/*.py",
+    "alphastats/plots/*.py",
+    "alphastats/statistics/*.py",
+    "alphastats/gui/utils/*.py",
+    "alphastats/gui/pages/*.py",
+    "alphastats/gui/*.py",
+    "nbs/**",
+    "tests/**",
+    "release/**",
+    "docs/**",
+]
+
+ignore = [
+    #
+    "PD002", #pandas-use-of-inplace-argument # TODO revisit
+
+    # same as pyproject.toml
+    "E501",  # Line too long  (ruff wraps code, but not docstrings)
+    "B028",  #  No explicit `stacklevel` keyword argument found (for warnings)
+    "B006", # Do not use mutable data structures for argument defaults # TODO: fix this!
+
+    # some more sensible ignores
+    "E501",  # Line too long  (ruff wraps code, but not docstrings)
+    "B028",  #  No explicit `stacklevel` keyword argument found (for warnings)
+    "COM812", #may cause conflicts when used with the formatter
+    "ISC001", #may cause conflicts when used with the formatter
+    "D211", # no-blank-line-before-class
+    "D213", # multi-line-summary-second-line
+    "S101", # Use of `assert` detected
+    "INP001", # implicit namespace package.
+    "ERA001", # Found commented-out code
+    "D203", # 1 blank line required before class docstring
+    "TD002", "TD003", "FIX002",  # things around TO-DO
+    "PT011", #pytest.raises(ValueError) is too broad
+    "G004", "EM102", # Logging statement uses f-string
+    "TRY003", # Avoid specifying long messages outside the exception class
+    "ANN101", # Missing type annotation for `self` in method
+    "ANN102", # Missing type annotation for `cls` in classmethod
+    "ANN002", # Missing type annotation for `*args`
+    "ANN003", # Missing type annotation for `**kwargs
+    "FA102", # Missing `from __future__ import annotations
+    "EM101", # Exception must not use a string literal, assign to variable first
+    "D104", # Missing docstring in public package
+    "ANN204", # Missing return type annotation for special method `__init__`
+    "D401", # First line of docstring should be in imperative mood
+    "B023", # Function definition does not bind loop variable
+    "PD901", # Avoid using the generic variable name `df` for DataFrames"
+    "TCH003" # Move standard library import into a type-checking block
+]


### PR DESCRIPTION
Add a ruleset for stricter linting.
Note: all code is currently excluded, this is on purpose to enable a step-wise approach to make the code comply with the stricter rules.