### PR TITLE
Add type based string representation of artifacts

### DIFF
--- a/alphastats/llm/llm_integration.py
+++ b/alphastats/llm/llm_integration.py
@@ -354,7 +354,9 @@ class LLMIntegration:
 
             content = json.dumps(
                 {
-                    MessageKeys.RESULT: str(function_result),
+                    MessageKeys.RESULT: self._str_repr(
+                        function_result, function_name, function_args
+                    ),
                     MessageKeys.ARTIFACT_ID: artifact_id,
                 }
             )
@@ -366,6 +368,32 @@ class LLMIntegration:
         response = self._chat_completion_create()
 
         return self._parse_model_response(response)
+
+    @staticmethod
+    def _str_repr(function_result: Any, function_name: str, function_args: Dict) -> str:
+        """Create a string representation of the function result.
+
+        Parameters
+        ----------
+        function_result : Any
+            The result of the function call
+        function_name : str
+            The name of the function
+        function_args : Dict
+            The arguments passed to the function
+
+        Returns
+        -------
+        str
+            A string representation of the function result
+        """
+        result_type = type(function_result)
+        if result_type in [pd.DataFrame, list, tuple, set, int, float, str]:
+            return str(function_result)
+        elif result_type is dict:
+            return json.dumps(function_result)
+        else:
+            return f"Function {function_name} with arguments {json.dumps(function_args)} returned a {result_type}. There is currently no text representation for this object that you would be able to interpret meaningfully. If the user asks for guidance how to interpret the artifact please rely on the desription of the function and the arguments."
 
     def _chat_completion_create(self) -> ChatCompletion:
         """Create a chat completion based on the current conversation history."""

--- a/alphastats/llm/llm_integration.py
+++ b/alphastats/llm/llm_integration.py
@@ -445,8 +445,6 @@ class LLMIntegration:
         messages, _, _ = self.get_print_view(show_all=True)
         chatlog = ""
         for message in messages:
-            if message[MessageKeys.ROLE] == Roles.TOOL:
-                continue
             chatlog += f"{message[MessageKeys.ROLE].capitalize()}: {message[MessageKeys.CONTENT]}\n"
             if len(message[MessageKeys.ARTIFACTS]) > 0:
                 chatlog += "-----\n"

--- a/alphastats/llm/llm_integration.py
+++ b/alphastats/llm/llm_integration.py
@@ -388,10 +388,12 @@ class LLMIntegration:
             A string representation of the function result
         """
         result_type = type(function_result)
-        if result_type in [pd.DataFrame, list, tuple, set, int, float, str]:
+        if result_type in [list, tuple, set, int, float, str, bool]:
             return str(function_result)
         elif result_type is dict:
             return json.dumps(function_result)
+        elif result_type is pd.DataFrame:
+            return function_result.to_json()
         else:
             return f"Function {function_name} with arguments {json.dumps(function_args)} returned a {result_type}. There is currently no text representation for this object that you would be able to interpret meaningfully. If the user asks for guidance how to interpret the artifact please rely on the desription of the function and the arguments."
 

--- a/tests/llm/test_llm_integration.py
+++ b/tests/llm/test_llm_integration.py
@@ -616,13 +616,13 @@ def test_get_print_view_show_all(llm_with_conversation: LLMIntegration):
             ("DataFrame", pd.DataFrame([[1, 2, 3]], columns=["a", "b", "c"])),
             "some_function_name",
             {"returns": "a tuple with non-primitive elements"},
-            'Function some_function_name with arguments {"returns": "a tuple with non-primitive elements"} returned a tuple, containing 2 elements, some of which are non-trivial to represent as text. There is currently no text representation for this collection that you would be able to interpret meaningfully. If the user asks for guidance how to interpret the artifact please rely on the desription of the function and the arguments.',
+            'Function some_function_name with arguments {"returns": "a tuple with non-primitive elements"} returned a tuple, containing 2 elements, some of which are non-trivial to represent as text. There is currently no text representation for this artifact that can be interpreted meaningfully. If the user asks for guidance how to interpret the artifact please rely on the desription of the tool function and the arguments it was called with.',
         ),
         (
             {"DataFrame": pd.DataFrame([[1, 2, 3]], columns=["a", "b", "c"])},
             "some_function_name",
             {"returns": "a dictionary with non-primitive values"},
-            'Function some_function_name with arguments {"returns": "a dictionary with non-primitive elements"} returned a dictionary, containing 1 values, some of which are non-trivial to represent as text. There is currently no text representation for this collection that you would be able to interpret meaningfully. If the user asks for guidance how to interpret the artifact please rely on the desription of the function and the arguments.',
+            'Function some_function_name with arguments {"returns": "a dictionary with non-primitive values"} returned a dict, containing 1 elements, some of which are non-trivial to represent as text. There is currently no text representation for this artifact that can be interpreted meaningfully. If the user asks for guidance how to interpret the artifact please rely on the desription of the tool function and the arguments it was called with.',
         ),
         (
             pd.DataFrame([[1, 2, 3]], columns=["a", "b", "c"]),
@@ -634,7 +634,7 @@ def test_get_print_view_show_all(llm_with_conversation: LLMIntegration):
             go.Figure(),
             "some_function_name",
             {"arg1": "value1"},
-            'Function some_function_name with arguments {"arg1": "value1"} returned a Figure. There is currently no text representation for this object that you would be able to interpret meaningfully. If the user asks for guidance how to interpret the artifact please rely on the desription of the function and the arguments.',
+            'Function some_function_name with arguments {"arg1": "value1"} returned a Figure. There is currently no text representation for this artifact that can be interpreted meaningfully. If the user asks for guidance how to interpret the artifact please rely on the desription of the tool function and the arguments it was called with.',
         ),
     ],
 )

--- a/tests/llm/test_llm_integration.py
+++ b/tests/llm/test_llm_integration.py
@@ -593,26 +593,55 @@ def test_get_print_view_show_all(llm_with_conversation: LLMIntegration):
 @pytest.mark.parametrize(
     "function_result, function_name, function_args, output",
     [
-        ("result", "function_name", {"arg1": "value1"}, "result"),
-        ([1, 2, 3], "function_name", {"arg1": "value1"}, str([1, 2, 3])),
-        ({"arg1": "value1"}, "function_name", {"arg1": "value1"}, '{"arg1": "value1"}'),
         (
-            go.Figure(),
-            "function_name",
+            "primitive_result",
+            "some_function_name",
             {"arg1": "value1"},
-            'Function function_name with arguments {"arg1": "value1"} returned a <class '
-            + "'plotly.graph_objs._figure.Figure'>. There is currently no text representation for this object that you would be able to interpret meaningfully. If the user asks for guidance how to interpret the artifact please rely on the desription of the function and the arguments.",
+            "primitive_result",
+        ),
+        ([1, 2, 3], "some_function_name", {"returns": "primitive list"}, "[1, 2, 3]"),
+        (
+            ("arg1", 1),
+            "some_function_name",
+            {"returns": "a tuple with primitive values"},
+            "('arg1', 1)",
+        ),
+        (
+            {"arg1": "value1"},
+            "some_function_name",
+            {"returns": "a dictionary with primitive values"},
+            "{'arg1': 'value1'}",
+        ),
+        (
+            ("DataFrame", pd.DataFrame([[1, 2, 3]], columns=["a", "b", "c"])),
+            "some_function_name",
+            {"returns": "a tuple with non-primitive elements"},
+            'Function some_function_name with arguments {"returns": "a tuple with non-primitive elements"} returned a tuple, containing 2 elements, some of which are non-trivial to represent as text. There is currently no text representation for this collection that you would be able to interpret meaningfully. If the user asks for guidance how to interpret the artifact please rely on the desription of the function and the arguments.',
+        ),
+        (
+            {"DataFrame": pd.DataFrame([[1, 2, 3]], columns=["a", "b", "c"])},
+            "some_function_name",
+            {"returns": "a dictionary with non-primitive values"},
+            'Function some_function_name with arguments {"returns": "a dictionary with non-primitive elements"} returned a dictionary, containing 1 values, some of which are non-trivial to represent as text. There is currently no text representation for this collection that you would be able to interpret meaningfully. If the user asks for guidance how to interpret the artifact please rely on the desription of the function and the arguments.',
         ),
         (
             pd.DataFrame([[1, 2, 3]], columns=["a", "b", "c"]),
-            "function_name",
+            "some_function_name",
             {"arg1": "value1"},
             r'{"a":{"0":1},"b":{"0":2},"c":{"0":3}}',
+        ),
+        (
+            go.Figure(),
+            "some_function_name",
+            {"arg1": "value1"},
+            'Function some_function_name with arguments {"arg1": "value1"} returned a Figure. There is currently no text representation for this object that you would be able to interpret meaningfully. If the user asks for guidance how to interpret the artifact please rely on the desription of the function and the arguments.',
         ),
     ],
 )
 def test_str_repr(function_result, function_name, function_args, output):
     assert (
-        LLMIntegration._str_repr(function_result, function_name, function_args)
+        LLMIntegration._create_string_representation(
+            function_result, function_name, function_args
+        )
         == output
     )


### PR DESCRIPTION
This is to reduce the token size of artifacts that the LLM can not interpret meaningfully.