### PR TITLE
Simplify and fix protein selector

### DIFF
--- a/alphastats/gui/pages/06_LLM.py
+++ b/alphastats/gui/pages/06_LLM.py
@@ -17,7 +17,6 @@ from alphastats.gui.utils.llm_helper import (
     LLM_ENABLED_ANALYSIS,
     OLLAMA_BASE_URL,
     display_uniprot,
-    get_df_for_protein_selector,
     protein_selector,
 )
 from alphastats.gui.utils.state_keys import DefaultStates, LLMKeys, StateKeys
@@ -128,21 +127,15 @@ if selected_llm_chat.get(LLMKeys.SELECTED_UNIPROT_FIELDS) is None:
 # Create dataframes with checkboxes for selection
 if selected_llm_chat.get(LLMKeys.SELECTED_GENES_UP) is None:
     selected_llm_chat[LLMKeys.SELECTED_GENES_UP] = upregulated_genes
-upregulated_genes_df = get_df_for_protein_selector(
-    upregulated_genes, selected_llm_chat[LLMKeys.SELECTED_GENES_UP]
-)
 
 if selected_llm_chat.get(LLMKeys.SELECTED_GENES_DOWN) is None:
     selected_llm_chat[LLMKeys.SELECTED_GENES_DOWN] = downregulated_genes
-downregulated_genes_df = get_df_for_protein_selector(
-    downregulated_genes, selected_llm_chat[LLMKeys.SELECTED_GENES_DOWN]
-)
 
 
 with c1:
     st.markdown("##### Genes of interest")
     protein_selector(
-        upregulated_genes_df,
+        upregulated_genes,
         "Upregulated Proteins",
         selected_analysis_key,
         state_key=LLMKeys.SELECTED_GENES_UP,
@@ -151,7 +144,7 @@ with c1:
 with c2:
     st.markdown("##### ")
     protein_selector(
-        downregulated_genes_df,
+        downregulated_genes,
         "Downregulated Proteins",
         selected_analysis_key,
         state_key=LLMKeys.SELECTED_GENES_DOWN,

--- a/alphastats/gui/pages/06_LLM.py
+++ b/alphastats/gui/pages/06_LLM.py
@@ -15,7 +15,7 @@ from alphastats.gui.utils.llm_helper import (
     OLLAMA_BASE_URL,
     display_uniprot,
     init_llm_chat_state,
-    pretty_print_analysis
+    pretty_print_analysis,
     protein_selector,
     show_llm_chat,
 )


### PR DESCRIPTION
Bug was that click None, select few, click None didn't work. Same for the all button. The second click didn't do anything.

Fix: check if list changes upon edit and st.rerun

Simplification: Only rerun the fragment - this required adding the df generation into the fragment.

Note: This makes is a necessity to always update the initial prompt (full page rerun would have avoided that), which is already the case for other changes.