### PR TITLE
Fix enrichment tools

### DIFF
--- a/alphastats/dataset/dataset.py
+++ b/alphastats/dataset/dataset.py
@@ -104,6 +104,8 @@ class DataSet:
         self.mat: pd.DataFrame = mat
         self.metadata: pd.DataFrame = metadata
         self.preprocessing_info: Dict = preprocessing_info
+
+        # TODO: Make these public attributes
         (
             self._gene_to_features_map,
             self._protein_to_features_map,

--- a/alphastats/llm/enrichment_analysis.py
+++ b/alphastats/llm/enrichment_analysis.py
@@ -2,21 +2,33 @@ from typing import List
 
 import pandas as pd
 import requests
+import streamlit as st
 from gprofiler import GProfiler
 
+from alphastats.dataset.dataset import DataSet
+from alphastats.gui.utils.state_utils import StateKeys
 
-def _get_functional_annotation_string(identifier, species_id="9606") -> pd.DataFrame:
+
+def _get_functional_annotation_string(
+    identifiers: list, background_identifiers: list = None, species_id: str = "9606"
+) -> pd.DataFrame:
     """
     Get functional annotation from STRING for a gene identifier.
 
     Args:
-        identifier (str): A gene identifier.
+        identifiers (list): A list of String gene identifiers.
+        background_identifiers (list, optional): A list of background gene identifiers.
         species_id (str, optional): The Uniprot organism ID to search in.
 
     Returns:
         pd.DataFrame: The functional annotation data.
     """
-    url = f"https://string-db.org/api/json/enrichment?identifiers={identifier}&species={int(species_id)}&caller_identity=alphapeptstats"
+    identifiers = "%0d".join(identifiers)
+    if background_identifiers:
+        background_identifiers = "&background_string_identifiers=" + "%0d".join(
+            background_identifiers
+        )
+    url = f"https://string-db.org/api/json/enrichment?identifiers={identifiers}{background_identifiers}&species={int(species_id)}&caller_identity=alphapeptstats"
     response = requests.get(url)
 
     if response.status_code == 200:
@@ -25,6 +37,55 @@ def _get_functional_annotation_string(identifier, species_id="9606") -> pd.DataF
         return df
     else:
         print(f"Request failed with status code {response.status_code}")
+        return None
+
+
+def _map_representation_to_string(
+    representations: List[str], species: str = "9606"
+) -> List[str]:
+    """
+    Map feature representations to STRING identifiers.
+
+    Modified from https://string-db.org/cgi/help.pl?subpage=api%23mapping-identifiers.
+
+    Args:
+        representations (list[str]): A list of feature representations.
+        species (str, optional): The species to map to.
+
+    Returns:
+        list[str]: The mapped STRING identifiers.
+    """
+
+    identifiers = [
+        input_repr.split(";")[0].split(":")[-1] for input_repr in representations
+    ]
+
+    string_api_url = "https://version-12-0.string-db.org/api"
+    output_format = "tsv-no-header"
+    method = "get_string_ids"
+
+    params = {
+        "identifiers": "\r".join(identifiers),  # your protein list
+        "species": species,  # NCBI/STRING taxon identifier
+        "limit": 1,  # only one (best) identifier per input protein
+        "echo_query": 1,  # see your input identifiers in the output
+        "caller_identity": "alphapeptstats",  # your app name
+    }
+
+    request_url = "/".join([string_api_url, output_format, method])
+
+    response = requests.post(request_url, data=params)
+    if response.status_code == 200:
+        print(response.text)
+        results = response.text.strip()
+        string_identifiers = []
+        for line in results.split("\n"):
+            string_identifiers.append(line.split("\t")[2])
+        return string_identifiers
+    else:
+        print(
+            f"Request to map string identifiers failed with status code {response.status_code}"
+        )
         return None
 
 
@@ -47,7 +108,10 @@ def _get_functional_annotation_gprofiler(identifiers: List[str]) -> pd.DataFrame
 
 
 def get_enrichment_data(
-    difexpressed: List[str], organism_id: str = 9606, tool: str = "gprofiler"
+    difexpressed: List[str],
+    organism_id: str = "9606",
+    tool: str = "gprofiler",
+    include_background: bool = False,
 ) -> pd.DataFrame:
     """
     Get enrichment data for a list of differentially expressed genes.
@@ -56,6 +120,7 @@ def get_enrichment_data(
         difexpressed (list[str]): A list of differentially expressed genes.
         organism_id (str, optional): The Uniprot organism ID to search in.
         tool (str, optional): The tool to use for enrichment analysis.
+        include_background (bool, optional): Whether to include background genes.
 
     Returns:
         pd.DataFrame: The enrichment data.
@@ -66,6 +131,20 @@ def get_enrichment_data(
     ], "Tool must be either 'gprofiler' or 'string'"
     if tool == "gprofiler":
         enrichment_data = _get_functional_annotation_gprofiler(difexpressed)
+    if tool == "string":
+        if include_background:
+            dataset: DataSet = st.session_state.get(StateKeys.DATASET)
+            background_identifiers = _map_representation_to_string(
+                dataset._feature_to_repr_map.values(), organism_id
+            )
+        else:
+            background_identifiers = None
+        identifiers = _map_representation_to_string(difexpressed, organism_id)
+        enrichment_data = _get_functional_annotation_string(
+            identifiers=identifiers,
+            background_identifiers=background_identifiers,
+            species_id=organism_id,
+        )
     else:
         enrichment_data = _get_functional_annotation_string(
             "%0d".join(difexpressed), organism_id

--- a/alphastats/llm/enrichment_analysis.py
+++ b/alphastats/llm/enrichment_analysis.py
@@ -179,6 +179,8 @@ def _get_functional_annotation_gprofiler(
         raise Warning(
             f"Organism {organism} not necessarily supported by g:Profiler. Supported organisms are {gprofiler_organisms.values()}",
         )
+    if not query:
+        raise ValueError("No query genes provided for enrichment analysis.")
     gp = GProfiler(
         user_agent="AlphaPeptStats",
         return_dataframe=True,

--- a/alphastats/llm/enrichment_analysis.py
+++ b/alphastats/llm/enrichment_analysis.py
@@ -360,7 +360,7 @@ def _get_background(background: list[str]) -> list[str]:
     try:
         dataset: DataSet = _get_dataset()
     except Exception as e:
-        if background is None:
+        if not background:
             raise ValueError(
                 "Background identifiers must be provided as additional argument if enrichment is not run from the GUI."
             ) from e

--- a/alphastats/llm/enrichment_analysis.py
+++ b/alphastats/llm/enrichment_analysis.py
@@ -8,6 +8,7 @@ import pandas as pd
 import requests
 from gprofiler import GProfiler
 
+from alphastats.dataset.dataset import DataSet
 from alphastats.gui.utils.state_keys import StateKeys
 
 if TYPE_CHECKING:
@@ -313,6 +314,28 @@ def get_enrichment_data(
     return enrichment_data
 
 
+def _get_dataset() -> DataSet:
+    """Get the dataset from the session state.
+
+    Returns
+    -------
+    DataSet
+        The dataset from the session state.
+
+    Raises
+    ------
+    ValueError
+        If no dataset is found in the session state.
+
+    """
+    import streamlit as st
+
+    dataset: DataSet = st.session_state.get(StateKeys.DATASET, None)
+    if dataset is None:
+        raise ValueError("No dataset found in the session state.")
+    return dataset
+
+
 def _get_background(background: list[str]) -> list[str]:
     """Get the background identifiers for enrichment analysis.
 
@@ -335,9 +358,7 @@ def _get_background(background: list[str]) -> list[str]:
 
     """
     try:
-        import streamlit as st
-
-        dataset: DataSet = st.session_state[StateKeys.DATASET]
+        dataset: DataSet = _get_dataset()
     except Exception as e:
         if background is None:
             raise ValueError(

--- a/alphastats/llm/llm_functions.py
+++ b/alphastats/llm/llm_functions.py
@@ -162,7 +162,7 @@ def get_general_assistant_functions() -> List[Dict]:
                         "tool": {
                             "type": "string",
                             "description": "The tool to use for enrichment analysis. String output includes member names and can therefore be more useful for downstream analysis. Gprofiler output uses fewer tokens.",
-                            "enum": ["string", "grpofiler"],
+                            "enum": ["string", "gprofiler"],
                         },
                         "include_background": {
                             "type": "boolean",

--- a/alphastats/llm/llm_functions.py
+++ b/alphastats/llm/llm_functions.py
@@ -164,8 +164,12 @@ def get_general_assistant_functions() -> List[Dict]:
                             "description": "The tool to use for enrichment analysis",
                             "enum": ["gprofiler", "string"],
                         },
+                        "include_background": {
+                            "type": "boolean",
+                            "description": "Whether to include background genes",
+                        },
                     },
-                    "required": ["difexpressed", "organism_id"],
+                    "required": ["difexpressed", "organism_id", "tool"],
                 },
             },
         },

--- a/alphastats/llm/llm_functions.py
+++ b/alphastats/llm/llm_functions.py
@@ -157,16 +157,16 @@ def get_general_assistant_functions() -> List[Dict]:
                         },
                         "organism_id": {
                             "type": "string",
-                            "description": f"The organism ID to search in, use keys from this dictionary: {gprofiler_organisms}. If you are unsure which organism to use, ask the user.",
+                            "description": f"The organism ID to search in, use keys from this dictionary: '{gprofiler_organisms}'. If you are unsure which organism to use, ask the user.",
                         },
                         "tool": {
                             "type": "string",
-                            "description": "The tool to use for enrichment analysis. String output includes member names and can therefore be more useful for downstream analysis. Gprofiler output uses fewer tokens.",
+                            "description": "The tool to use for enrichment analysis. String output includes names of input identifiers belonging to each enriched term and can therefore be more useful for downstream analysis. Gprofiler output is more concise.",
                             "enum": ["string", "gprofiler"],
                         },
                         "include_background": {
                             "type": "boolean",
-                            "description": "Whether to include background genes. This can significantly alter results and should be turned on when the experiment has significantly lower depth than a the full organism annotaiton.",
+                            "description": "Whether to include background genes. This can significantly alter results and should be turned on when the experiment has significantly lower depth than a the full organism annotation.",
                         },
                     },
                     "required": ["difexpressed", "organism_id", "tool"],

--- a/alphastats/llm/prompts.py
+++ b/alphastats/llm/prompts.py
@@ -22,6 +22,7 @@ def get_system_message(dataset: DataSet) -> str:
         f"The data you have has following groups and respective subgroups: {str(subgroups)}."
         "Plots are visualized using a graphical environment capable of rendering images, you don't need to worry about that. If the data coming to"
         " you from a function has references to the literature (for example, PubMed), always quote the references in your response."
+        " The next message will be referred to as the initial prompt by tools and potentially by the user."
     )
 
 

--- a/ruff-lint-strict.toml
+++ b/ruff-lint-strict.toml
@@ -11,7 +11,11 @@ exclude = [
     "alphastats/cli.py",
     "alphastats/data/*.py",
     "alphastats/dataset/*.py",
-    "alphastats/llm/*.py",
+    "alphastats/llm/llm_functions.py",
+    "alphastats/llm/llm_integration.py",
+    "alphastats/llm/llm_utils.py",
+    "alphastats/llm/prompts.py",
+    "alphastats/llm/uniprot_utils.py",
     "alphastats/loader/*.py",
     "alphastats/multicova/*.py",
     "alphastats/plots/*.py",
@@ -62,7 +66,6 @@ ignore = [
     "ANN102", # Missing type annotation for `cls` in classmethod
     "ANN002", # Missing type annotation for `*args`
     "ANN003", # Missing type annotation for `**kwargs
-    "FA102", # Missing `from __future__ import annotations
     "EM101", # Exception must not use a string literal, assign to variable first
     "D104", # Missing docstring in public package
     "ANN204", # Missing return type annotation for special method `__init__`

--- a/tests/llm/test_enrichment_analysis.py
+++ b/tests/llm/test_enrichment_analysis.py
@@ -1,0 +1,505 @@
+from unittest.mock import Mock, patch
+
+import pandas as pd
+import pytest
+import requests
+
+from alphastats.llm.enrichment_analysis import (
+    StateKeys,
+    _get_functional_annotation_gprofiler,
+    _get_functional_annotation_string,
+    _map_short_representation_to_string,
+    _shorten_representations,
+    get_enrichment_data,
+)
+
+
+@patch("alphastats.llm.enrichment_analysis.requests.post")
+def test_successful_response(mock_post):
+    # Mock response from STRING API
+    mock_response = Mock()
+    mock_response.json.return_value = [
+        {
+            "term": "GO:0008150",
+            "description": "biological_process",
+            "p_value": 0.01,
+            "ncbiTaxonId": 9606,
+            "inputGenes": ["gene1", "gene2"],
+        },
+        {
+            "term": "GO:0003674",
+            "description": "molecular_function",
+            "p_value": 0.05,
+            "ncbiTaxonId": 9606,
+            "inputGenes": ["gene3"],
+        },
+    ]
+    mock_post.return_value = mock_response
+
+    identifiers = ["gene1", "gene2", "gene3"]
+    result = _get_functional_annotation_string(identifiers)
+
+    # Assert that the mock was called with the correct arguments
+    mock_post.assert_called_with(
+        "https://string-db.org/api/json/enrichment",
+        data={
+            "identifiers": "%0d".join(identifiers),
+            "species": "9606",
+            "caller_identity": "alphapeptstats",
+        },
+        timeout=600,
+    )
+
+    # Expected DataFrame
+    expected_data = [
+        {"term": "GO:0008150", "description": "biological_process", "p_value": 0.01},
+        {"term": "GO:0003674", "description": "molecular_function", "p_value": 0.05},
+    ]
+    expected_df = pd.DataFrame(expected_data)
+
+    pd.testing.assert_frame_equal(result, expected_df)
+
+
+@patch("alphastats.llm.enrichment_analysis.requests.post")
+def test_request_timeout(mock_post):
+    # Simulate a timeout exception
+    mock_post.side_effect = requests.exceptions.Timeout
+
+    identifiers = ["gene1", "gene2", "gene3"]
+    with pytest.raises(ValueError, match="Request to STRING API timed out"):
+        _get_functional_annotation_string(identifiers)
+
+
+@patch("alphastats.llm.enrichment_analysis.requests.post")
+def test_request_failure(mock_post):
+    # Simulate a generic request exception
+    mock_post.side_effect = requests.exceptions.RequestException("Connection error")
+
+    identifiers = ["gene1", "gene2", "gene3"]
+    with pytest.raises(ValueError, match="Request to STRING API failed"):
+        _get_functional_annotation_string(identifiers)
+
+
+@patch("alphastats.llm.enrichment_analysis.requests.post")
+def test_with_background_identifiers(mock_post):
+    # Mock response from STRING API
+    mock_response = Mock()
+    mock_response.json.return_value = [
+        {
+            "term": "GO:0008150",
+            "description": "biological_process",
+            "p_value": 0.01,
+            "ncbiTaxonId": 9606,
+            "inputGenes": ["gene1", "gene2"],
+        },
+    ]
+    mock_post.return_value = mock_response
+
+    identifiers = ["gene1", "gene2"]
+    background_identifiers = ["gene3", "gene4"]
+    result = _get_functional_annotation_string(identifiers, background_identifiers)
+
+    # Assert that the mock was called with the correct arguments
+    mock_post.assert_called_with(
+        "https://string-db.org/api/json/enrichment",
+        data={
+            "identifiers": "%0d".join(identifiers),
+            "background_string_identifiers": "%0d".join(background_identifiers),
+            "species": "9606",
+            "caller_identity": "alphapeptstats",
+        },
+        timeout=600,
+    )
+
+    # Expected DataFrame
+    expected_data = [
+        {"term": "GO:0008150", "description": "biological_process", "p_value": 0.01},
+    ]
+    expected_df = pd.DataFrame(expected_data)
+
+    pd.testing.assert_frame_equal(result, expected_df)
+
+
+@patch("alphastats.llm.enrichment_analysis.requests.post")
+def test_map_short_representation_to_string_success(mock_post):
+    # Mock response from STRING API
+    mock_response = Mock()
+    mock_response.text = "input1\tquery1\tSTRING_ID1\ninput2\tquery2\tSTRING_ID2"
+    mock_post.return_value = mock_response
+
+    short_representations = ["input1", "input2"]
+    result = _map_short_representation_to_string(short_representations)
+
+    # Assert that the mock was called with the correct arguments
+    mock_post.assert_called_with(
+        "https://version-12-0.string-db.org/api/tsv-no-header/get_string_ids",
+        data={
+            "identifiers": "\r".join(short_representations),
+            "species": "9606",
+            "limit": 1,
+            "echo_query": 1,
+            "caller_identity": "alphapeptstats",
+        },
+        timeout=600,
+    )
+
+    # Expected result
+    expected_result = ["STRING_ID1", "STRING_ID2"]
+    assert result == expected_result
+
+
+@patch("alphastats.llm.enrichment_analysis.requests.post")
+def test_map_short_representation_to_string_timeout(mock_post):
+    # Simulate a timeout exception
+    mock_post.side_effect = requests.exceptions.Timeout
+
+    short_representations = ["input1", "input2"]
+    with pytest.raises(ValueError, match="Request to STRING API timed out"):
+        _map_short_representation_to_string(short_representations)
+
+
+@patch("alphastats.llm.enrichment_analysis.requests.post")
+def test_map_short_representation_to_string_request_failure(mock_post):
+    # Simulate a generic request exception
+    mock_post.side_effect = requests.exceptions.RequestException("Connection error")
+
+    short_representations = ["input1", "input2"]
+    with pytest.raises(ValueError, match="Request to STRING API failed"):
+        _map_short_representation_to_string(short_representations)
+
+
+@patch("alphastats.llm.enrichment_analysis.requests.post")
+def test_map_short_representation_to_string_empty_response(mock_post):
+    # Simulate an empty response
+    mock_response = Mock()
+    mock_response.text = ""
+    mock_post.return_value = mock_response
+
+    short_representations = ["input1", "input2"]
+    with pytest.raises(
+        ValueError, match="No identifiers could be mapped to STRING identifiers."
+    ):
+        _map_short_representation_to_string(short_representations)
+
+
+def test_shorten_representations_custom_separator():
+    representations = ["gene1:info1|info2", "gene2:info3|info4", "gene3:info5|info6"]
+    result = _shorten_representations(representations, sep="|")
+    expected = ["info1", "info3", "info5"]
+    assert result == expected
+
+
+def test_shorten_representations_no_separator():
+    representations = ["gene1:info1", "gene2:info2", "gene3:info3"]
+    result = _shorten_representations(representations)
+    expected = ["info1", "info2", "info3"]
+    assert result == expected
+
+
+def test_shorten_representations_empty_list():
+    representations = []
+    result = _shorten_representations(representations)
+    expected = []
+    assert result == expected
+
+
+def test_shorten_representations_no_colon():
+    representations = ["gene1;info1", "gene2;info2", "gene3;info3"]
+    result = _shorten_representations(representations)
+    expected = ["gene1", "gene2", "gene3"]
+    assert result == expected
+
+
+def test_shorten_representations_mixed_format():
+    representations = ["gene1:info1;info2", "gene2;info3", "gene3:info4"]
+    result = _shorten_representations(representations)
+    expected = ["info1", "gene2", "info4"]
+    assert result == expected
+
+
+@patch("alphastats.llm.enrichment_analysis.GProfiler")
+def test_get_functional_annotation_gprofiler_success(mock_gprofiler):
+    # Mock g:Profiler response
+    mock_gp_instance = Mock()
+    mock_gp_instance.profile.return_value = pd.DataFrame(
+        {
+            "term": ["GO:0008150", "GO:0003674"],
+            "description": ["biological_process", "molecular_function"],
+            "p_value": [0.01, 0.05],
+        }
+    )
+    mock_gprofiler.return_value = mock_gp_instance
+
+    query = ["gene1", "gene2"]
+    background = ["gene3", "gene4"]
+    organism = "hsapiens"
+
+    result = _get_functional_annotation_gprofiler(query, background, organism)
+
+    # Assert that g:Profiler was called with the correct arguments
+    mock_gp_instance.profile.assert_called_with(
+        query=query, organism=organism, background=background
+    )
+
+    # Expected DataFrame
+    expected_df = pd.DataFrame(
+        {
+            "term": ["GO:0008150", "GO:0003674"],
+            "description": ["biological_process", "molecular_function"],
+            "p_value": [0.01, 0.05],
+        }
+    )
+
+    pd.testing.assert_frame_equal(result, expected_df)
+
+
+def test_get_functional_annotation_gprofiler_unsupported_organism():
+    query = ["gene1", "gene2"]
+    background = ["gene3", "gene4"]
+    organism = "unsupported_organism"
+
+    with pytest.raises(
+        Warning, match=f"Organism {organism} not necessarily supported by g:Profiler"
+    ):
+        _get_functional_annotation_gprofiler(query, background, organism)
+
+
+@patch("alphastats.llm.enrichment_analysis.GProfiler")
+def test_get_functional_annotation_gprofiler_no_background(mock_gprofiler):
+    # Mock g:Profiler response
+    mock_gp_instance = Mock()
+    mock_gp_instance.profile.return_value = pd.DataFrame(
+        {
+            "term": ["GO:0008150"],
+            "description": ["biological_process"],
+            "p_value": [0.01],
+        }
+    )
+    mock_gprofiler.return_value = mock_gp_instance
+
+    query = ["gene1", "gene2"]
+    organism = "hsapiens"
+
+    result = _get_functional_annotation_gprofiler(query, organism=organism)
+
+    # Assert that g:Profiler was called with the correct arguments
+    mock_gp_instance.profile.assert_called_with(
+        query=query, organism=organism, background=None
+    )
+
+    # Expected DataFrame
+    expected_df = pd.DataFrame(
+        {
+            "term": ["GO:0008150"],
+            "description": ["biological_process"],
+            "p_value": [0.01],
+        }
+    )
+
+    pd.testing.assert_frame_equal(result, expected_df)
+
+
+@patch("alphastats.llm.enrichment_analysis.GProfiler")
+def test_get_functional_annotation_gprofiler_empty_query(mock_gprofiler):
+    # Mock g:Profiler response
+    mock_gp_instance = Mock()
+    mock_gp_instance.profile.return_value = pd.DataFrame()
+    mock_gprofiler.return_value = mock_gp_instance
+
+    query = []
+    organism = "hsapiens"
+
+    with pytest.raises(
+        ValueError, match="No query genes provided for enrichment analysis."
+    ):
+        _get_functional_annotation_gprofiler(query, organism=organism)
+
+    # Assert that g:Profiler was not called
+    mock_gp_instance.profile.assert_not_called()
+
+
+@patch("alphastats.llm.enrichment_analysis._get_functional_annotation_gprofiler")
+@patch("alphastats.llm.enrichment_analysis._shorten_representations")
+def test_get_enrichment_data_gprofiler(mock_shorten, mock_gprofiler):
+    # Mock shortened representations
+    mock_shorten.side_effect = lambda x: x
+
+    # Mock g:Profiler response
+    mock_gprofiler.return_value = pd.DataFrame(
+        {
+            "term": ["GO:0008150", "GO:0003674"],
+            "description": ["biological_process", "molecular_function"],
+            "p_value": [0.01, 0.05],
+        }
+    )
+
+    difexpressed = ["gene1", "gene2"]
+    background = ["gene1", "gene2", "gene3", "gene4"]
+    organism_id = "9606"
+    tool = "gprofiler"
+
+    result = get_enrichment_data(difexpressed, organism_id, tool, background=background)
+
+    # Assert that the mock functions were called with the correct arguments
+    mock_shorten.assert_any_call(difexpressed)
+    mock_shorten.assert_any_call(background)
+    mock_gprofiler.assert_called_with(
+        query=difexpressed,
+        background=background,
+        organism="hsapiens",
+    )
+
+    # Expected DataFrame
+    expected_df = pd.DataFrame(
+        {
+            "term": ["GO:0008150", "GO:0003674"],
+            "description": ["biological_process", "molecular_function"],
+            "p_value": [0.01, 0.05],
+        }
+    )
+
+    pd.testing.assert_frame_equal(result, expected_df)
+
+
+@patch("alphastats.llm.enrichment_analysis._get_functional_annotation_string")
+@patch("alphastats.llm.enrichment_analysis._map_short_representation_to_string")
+@patch("alphastats.llm.enrichment_analysis._shorten_representations")
+def test_get_enrichment_data_string(mock_shorten, mock_map, mock_string):
+    # Mock shortened representations
+    mock_shorten.side_effect = lambda x: x
+
+    # Mock STRING mapping
+    mock_map.side_effect = lambda x, _: x
+
+    # Mock STRING API response
+    mock_string.return_value = pd.DataFrame(
+        {
+            "term": ["GO:0008150"],
+            "description": ["biological_process"],
+            "p_value": [0.01],
+        }
+    )
+
+    difexpressed = ["gene1", "gene2"]
+    background = ["gene1", "gene2", "gene3", "gene4"]
+    organism_id = "9606"
+    tool = "string"
+
+    result = get_enrichment_data(difexpressed, organism_id, tool, background=background)
+
+    # Assert that the mock functions were called with the correct arguments
+    mock_shorten.assert_any_call(difexpressed)
+    mock_shorten.assert_any_call(background)
+    mock_map.assert_any_call(difexpressed, organism_id)
+    mock_map.assert_any_call(background, organism_id)
+    mock_string.assert_called_with(
+        identifiers=difexpressed,
+        background_identifiers=background,
+        species_id=organism_id,
+    )
+
+    # Expected DataFrame
+    expected_df = pd.DataFrame(
+        {
+            "term": ["GO:0008150"],
+            "description": ["biological_process"],
+            "p_value": [0.01],
+        }
+    )
+
+    pd.testing.assert_frame_equal(result, expected_df)
+
+
+def test_get_enrichment_data_invalid_tool():
+    difexpressed = ["gene1", "gene2"]
+    tool = "invalid_tool"
+
+    with pytest.raises(
+        ValueError,
+        match="Tool invalid_tool not supported. Must be either 'gprofiler' or 'string'.",
+    ):
+        get_enrichment_data(difexpressed, tool=tool)
+
+
+@patch("alphastats.llm.enrichment_analysis._get_functional_annotation_gprofiler")
+def test_get_enrichment_data_invalid_organism_gprofiler(mock_gprofiler):
+    difexpressed = ["gene1", "gene2"]
+    organism_id = "99999"  # Invalid organism ID for g:Profiler
+    tool = "gprofiler"
+
+    with pytest.raises(
+        ValueError, match=f"Organism ID {organism_id} not supported by g:Profiler"
+    ):
+        get_enrichment_data(difexpressed, organism_id, tool, include_background=False)
+
+
+@patch("alphastats.llm.enrichment_analysis._get_functional_annotation_string")
+def test_get_enrichment_data_no_background_provided(mock_string):
+    difexpressed = ["gene1", "gene2"]
+    tool = "string"
+
+    with pytest.raises(
+        ValueError,
+        match="Background identifiers must be provided as additional argument if enrichment is not run from the GUI.",
+    ):
+        get_enrichment_data(difexpressed, tool=tool, include_background=True)
+
+
+@patch("alphastats.llm.enrichment_analysis._get_functional_annotation_string")
+@patch("alphastats.llm.enrichment_analysis._map_short_representation_to_string")
+@patch("alphastats.llm.enrichment_analysis._shorten_representations")
+@patch("streamlit.session_state")
+def test_get_enrichment_data_with_streamlit_dataset(
+    mock_session_state, mock_shorten, mock_map, mock_string
+):
+    # Mock the dataset in Streamlit session state
+    mock_dataset = Mock()
+    mock_dataset._feature_to_repr_map.values.return_value = [
+        "gene1:info1",
+        "gene2:info2",
+        "gene3:info3",
+        "gene4:info4",
+    ]
+    mock_session_state.get.return_value = mock_dataset
+
+    # Mock shortened representations
+    mock_shorten.side_effect = lambda x: [item.split(":")[0] for item in x]
+
+    # Mock STRING mapping
+    mock_map.side_effect = lambda x, _: x
+
+    # Mock STRING API response
+    mock_string.return_value = pd.DataFrame(
+        {
+            "term": ["GO:0008150"],
+            "description": ["biological_process"],
+            "p_value": [0.01],
+        }
+    )
+
+    difexpressed = ["gene1", "gene2"]
+    organism_id = "9606"
+    tool = "string"
+
+    result = get_enrichment_data(
+        difexpressed, organism_id, tool, include_background=True
+    )
+
+    # Assert that the mock functions were called with the correct arguments
+    mock_session_state.get.assert_called_with(StateKeys.DATASET)
+    mock_string.assert_called_with(
+        identifiers=difexpressed,
+        background_identifiers=["gene1", "gene2", "gene3", "gene4"],
+        species_id=organism_id,
+    )
+
+    # Expected DataFrame
+    expected_df = pd.DataFrame(
+        {
+            "term": ["GO:0008150"],
+            "description": ["biological_process"],
+            "p_value": [0.01],
+        }
+    )
+
+    pd.testing.assert_frame_equal(result, expected_df)

--- a/tests/llm/test_enrichment_analysis.py
+++ b/tests/llm/test_enrichment_analysis.py
@@ -276,6 +276,7 @@ def test_get_functional_annotation_gprofiler_empty_query(mock_gprofiler):
 
 @patch("alphastats.llm.enrichment_analysis._get_functional_annotation_gprofiler")
 @patch("alphastats.llm.enrichment_analysis._shorten_representations")
+@patch("streamlit.session_state", {})
 def test_get_enrichment_data_gprofiler(mock_shorten, mock_gprofiler):
     mock_shorten.side_effect = lambda x: x
     mock_gprofiler.return_value = pd.DataFrame(
@@ -317,6 +318,7 @@ def test_get_enrichment_data_gprofiler(mock_shorten, mock_gprofiler):
 @patch("alphastats.llm.enrichment_analysis._get_functional_annotation_stringdb")
 @patch("alphastats.llm.enrichment_analysis._map_short_representation_to_stringdb")
 @patch("alphastats.llm.enrichment_analysis._shorten_representations")
+@patch("streamlit.session_state", {})
 def test_get_enrichment_data_string(mock_shorten, mock_map, mock_string):
     mock_shorten.side_effect = lambda x: x
     mock_map.side_effect = lambda x, _: x
@@ -381,16 +383,13 @@ def test_get_enrichment_data_invalid_organism_gprofiler(mock_gprofiler):
         get_enrichment_data(difexpressed, organism_id, tool, include_background=False)
 
 
-@patch("alphastats.llm.enrichment_analysis._get_functional_annotation_stringdb")
-def test_get_enrichment_data_no_background_provided(mock_string):
-    difexpressed = ["gene1", "gene2"]
-    tool = "string"
-
+@patch("streamlit.session_state", {})
+def test_get_background_data_no_background_provided():
     with pytest.raises(
         ValueError,
         match="Background identifiers must be provided as additional argument if enrichment is not run from the GUI.",
     ):
-        get_enrichment_data(difexpressed, tool=tool, include_background=True)
+        _get_background([])
 
 
 @patch("alphastats.llm.enrichment_analysis._shorten_representations")


### PR DESCRIPTION
I added id mapping, since the LLM gets fed the string representations.
I added backgorund inclusion, which unfortunately makes the whole thing depend on the Dataset, but pays off and is also something that other online enrichment tools often don't offer.

I edited the LLM instructions slightly and changed the defaults to string with background inclusion.