### PR TITLE
Fix intensity plot

### DIFF
--- a/alphastats/dataset/dataset.py
+++ b/alphastats/dataset/dataset.py
@@ -509,7 +509,7 @@ class DataSet:
             return self._gene_to_features_map[string]
         raise ValueError(f"Feature {string} is not in the (processed) data.")
 
-    def _get_multiple_features(self, features: List):
+    def _get_multiple_feature_ids_from_strings(self, features: List) -> List:
         """Get the feature ids from a list of strings representing features.
 
         Parameters
@@ -530,6 +530,8 @@ class DataSet:
             )
         if not protein_ids:
             raise ValueError("No valid features provided.")
+
+        return protein_ids
 
     def plot_intensity(
         self,
@@ -567,7 +569,7 @@ class DataSet:
             features = [substring.strip() for substring in feature.split(",")]
         else:
             features = [feature]
-        protein_id = self._get_multiple_features(features)
+        protein_id = self._get_multiple_feature_ids_from_strings(features)
 
         intensity_plot = IntensityPlot(
             mat=self.mat,

--- a/alphastats/gui/utils/analysis.py
+++ b/alphastats/gui/utils/analysis.py
@@ -251,7 +251,7 @@ class IntensityPlot(AbstractIntensityPlot, ABC):
     def _do_analysis(self):
         """Draw Intensity Plot using the IntensityPlot class."""
         intensity_plot = self._dataset.plot_intensity(
-            protein_id=self._parameters["protein_id"],
+            feature=self._parameters["protein_id"],
             method=self._parameters["method"],
             group=self._parameters["group"],
         )

--- a/alphastats/llm/llm_functions.py
+++ b/alphastats/llm/llm_functions.py
@@ -200,7 +200,7 @@ def get_assistant_functions(
                     "properties": {
                         "feature": {
                             "type": "string",
-                            "description": "Identifier for the feature of interest, use the same format as in the initial prompt, inidivual gene symbols, or individual protein ids",
+                            "description": "Identifier for the feature of interest. Use the same format as in the initial prompt, inidividual gene symbols, or individual protein ids.",
                         },
                         "group": {
                             "type": "string",

--- a/alphastats/llm/llm_functions.py
+++ b/alphastats/llm/llm_functions.py
@@ -198,10 +198,9 @@ def get_assistant_functions(
                 "parameters": {
                     "type": "object",
                     "properties": {
-                        "gene_name": {
+                        "feature": {
                             "type": "string",
-                            "enum": genes_of_interest,
-                            "description": "Identifier for the gene of interest",
+                            "description": "Identifier for the feature of interest, use the same format as in the initial prompt, inidivual gene symbols, or individual protein ids",
                         },
                         "group": {
                             "type": "string",
@@ -228,7 +227,7 @@ def get_assistant_functions(
                             "description": "Whether to use a logarithmic scale for the plot",
                         },
                     },
-                    "required": ["protein_id", "group"],
+                    "required": ["feature", "group"],
                 },
             },
         },

--- a/alphastats/plots/intensity_plot.py
+++ b/alphastats/plots/intensity_plot.py
@@ -42,6 +42,7 @@ class IntensityPlot(PlotUtils):
         intensity_column: str,
         preprocessing_info: Dict,
         protein_id,
+        feature_to_repr_map: Dict,
         group,
         subgroups=None,
         method,
@@ -54,6 +55,7 @@ class IntensityPlot(PlotUtils):
         self.preprocessing_info = preprocessing_info
 
         self.protein_id = [protein_id] if isinstance(protein_id, str) else protein_id
+        self.feature_to_repr_map = feature_to_repr_map
         self.group = group
         self.subgroups = subgroups
         self.method = method
@@ -135,7 +137,6 @@ class IntensityPlot(PlotUtils):
             font=dict(size=12, color="black"),
         )
 
-        plot.update_layout(width=600, height=700)
         return plot
 
     def _prepare_data(self):
@@ -203,11 +204,21 @@ class IntensityPlot(PlotUtils):
                 + "Please select from 'violin' for Violinplot, 'box' for Boxplot and 'scatter' for Scatterplot."
             )
 
+        fig.for_each_annotation(
+            lambda a: a.update(text=self.feature_to_repr_map[a.text.split("=")[-1]])
+        )
+
         if self.log_scale:
             fig.update_layout(yaxis=dict(type="log"))
 
         if self.add_significance:
             fig = self._add_significance(fig)
+
+        fig.update_layout(
+            width=100
+            + len(self.protein_id) * self.prepared_df[self.group].nunique() * 50,
+            height=500,
+        )
 
         fig = PlotlyObject(fig)
         self._update_figure_attributes(

--- a/nbs/liu_2019.ipynb
+++ b/nbs/liu_2019.ipynb
@@ -243,7 +243,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "61f94c80-535d-4b5f-82fc-df8196936f24",
    "metadata": {},
    "outputs": [
@@ -287,7 +287,7 @@
     "for protein in [\"LGALS3BP\", \"AFM\", \"SERPINC1\", \"CTSD;HEL-S-130P\", \"ALDOB\"]:\n",
     "    plot = dataset.plot_intensity(\n",
     "        method=\"all\",\n",
-    "        protein_id=protein,\n",
+    "        feature=protein,\n",
     "        group=\"disease\",  # column in metadata\n",
     "        subgroups=[\"T2DM\", \"T2DM+NAFLD\"],  # we only want to see T2DM and T2DM+NAFLD\n",
     "        add_significance=True,  # add bar with pvalue\n",

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -790,12 +790,12 @@ class TestMaxQuantDataSet(BaseTestDataSet.BaseTest):
         )
         self.assertEqual(res.shape[1], 45)
 
-    def test_get_protein_id_for_gene_name(self):
+    def test_get_feature_id_from_string(self):
         with self.assertRaises(ValueError):
-            self.obj._get_features_for_gene_name("MADE_UP_GENE"), "MADE_UP_GENE"
+            self.obj._get_feature_id_from_string("MADE_UP_GENE"), "MADE_UP_GENE"
 
         self.assertEqual(
-            self.obj._get_features_for_gene_name("ALDOC"),
+            self.obj._get_feature_id_from_string("ALDOC"),
             [
                 "P09972;A0A024QZ64;A8MVZ9;B7Z3K9;B7Z1N6;B7Z3K7;J3KSV6;J3QKP5;C9J8F3;B7Z1Z9;J3QKK1;B7Z1H6;K7EKH5;B7Z1L5"
             ],

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -792,10 +792,10 @@ class TestMaxQuantDataSet(BaseTestDataSet.BaseTest):
 
     def test_get_feature_id_from_string(self):
         with self.assertRaises(ValueError):
-            self.obj._get_feature_id_from_string("MADE_UP_GENE"), "MADE_UP_GENE"
+            self.obj._get_feature_ids_from_string("MADE_UP_GENE"), "MADE_UP_GENE"
 
         self.assertEqual(
-            self.obj._get_feature_id_from_string("ALDOC"),
+            self.obj._get_feature_ids_from_string("ALDOC"),
             [
                 "P09972;A0A024QZ64;A8MVZ9;B7Z3K9;B7Z1N6;B7Z3K7;J3KSV6;J3QKP5;C9J8F3;B7Z1Z9;J3QKK1;B7Z1H6;K7EKH5;B7Z1L5"
             ],

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -501,7 +501,7 @@ class TestMaxQuantDataSet(BaseTestDataSet.BaseTest):
 
     def test_plot_intenstity_subgroup(self):
         plot = self.obj.plot_intensity(
-            protein_id="K7ERI9;A0A024R0T8;P02654;K7EJI9;K7ELM9;K7EPF9;K7EKP1",
+            feature="K7ERI9;A0A024R0T8;P02654;K7EJI9;K7ELM9;K7EPF9;K7EKP1",
             group="disease",
             subgroups=["healthy", "liver cirrhosis"],
             add_significance=True,
@@ -511,7 +511,7 @@ class TestMaxQuantDataSet(BaseTestDataSet.BaseTest):
 
     def test_plot_intenstity_valid_gene(self):
         plot = self.obj.plot_intensity(
-            gene_name="ALDOC",
+            feature="ALDOC",
             group="disease",
         )
         plot_dict = plot.to_plotly_json()
@@ -520,13 +520,13 @@ class TestMaxQuantDataSet(BaseTestDataSet.BaseTest):
     def test_plot_intenstity_bogus_gene(self):
         with self.assertRaises(ValueError):
             self.obj.plot_intensity(
-                gene_name="BOGUSGENE",
+                feature="BOGUSGENE",
                 group="disease",
             )
 
     def test_plot_intensity_subgroup_gracefully_handle_one_group(self):
         plot = self.obj.plot_intensity(
-            protein_id="K7ERI9;A0A024R0T8;P02654;K7EJI9;K7ELM9;K7EPF9;K7EKP1",
+            feature="K7ERI9;A0A024R0T8;P02654;K7EJI9;K7ELM9;K7EPF9;K7EKP1",
             group="disease",
             add_significance=True,
         )
@@ -691,7 +691,7 @@ class TestMaxQuantDataSet(BaseTestDataSet.BaseTest):
         No significant label is added to intensity plot
         """
         plot = self.obj.plot_intensity(
-            protein_id="S6BAR0",
+            feature="S6BAR0",
             group="disease",
             subgroups=["liver cirrhosis", "healthy"],
             add_significance=True,
@@ -708,7 +708,7 @@ class TestMaxQuantDataSet(BaseTestDataSet.BaseTest):
         Significant label * is added to intensity plot
         """
         plot = self.obj.plot_intensity(
-            protein_id="Q9UL94",
+            feature="Q9UL94",
             group="disease",
             subgroups=["liver cirrhosis", "healthy"],
             add_significance=True,
@@ -725,7 +725,7 @@ class TestMaxQuantDataSet(BaseTestDataSet.BaseTest):
         Significant label ** is added to intensity plot
         """
         plot = self.obj.plot_intensity(
-            protein_id="Q96JD0;Q96JD1;P01721",
+            feature="Q96JD0;Q96JD1;P01721",
             group="disease",
             subgroups=["liver cirrhosis", "healthy"],
             add_significance=True,
@@ -742,7 +742,7 @@ class TestMaxQuantDataSet(BaseTestDataSet.BaseTest):
         Highly significant label is added to intensity plot
         """
         plot = self.obj.plot_intensity(
-            protein_id="Q9BWP8",
+            feature="Q9BWP8",
             group="disease",
             subgroups=["liver cirrhosis", "healthy"],
             add_significance=True,
@@ -756,7 +756,7 @@ class TestMaxQuantDataSet(BaseTestDataSet.BaseTest):
 
     def test_plot_intensity_all(self):
         plot = self.obj.plot_intensity(
-            protein_id="Q9BWP8",
+            feature="Q9BWP8",
             group="disease",
             subgroups=["liver cirrhosis", "healthy"],
             method="all",
@@ -828,7 +828,7 @@ class TestDIANNDataSet(BaseTestDataSet.BaseTest):
     def test_plot_intensity_violin(self):
         # Violinplot
         plot = self.obj.plot_intensity(
-            protein_id="A0A075B6H7", group="grouping1", method="violin"
+            feature="A0A075B6H7", group="grouping1", method="violin"
         )
         plot_dict = plot.to_plotly_json()
         self.assertIsInstance(plot, plotly.graph_objects.Figure)
@@ -838,7 +838,7 @@ class TestDIANNDataSet(BaseTestDataSet.BaseTest):
     def test_plot_intensity_box(self):
         # Boxplot
         plot = self.obj.plot_intensity(
-            protein_id="A0A075B6H7", group="grouping1", method="box", log_scale=True
+            feature="A0A075B6H7", group="grouping1", method="box", log_scale=True
         )
         plot_dict = plot.to_plotly_json()
         # log scale
@@ -849,7 +849,7 @@ class TestDIANNDataSet(BaseTestDataSet.BaseTest):
     def test_plot_intensity_scatter(self):
         # Scatterplot
         plot = self.obj.plot_intensity(
-            protein_id="A0A075B6H7", group="grouping1", method="scatter"
+            feature="A0A075B6H7", group="grouping1", method="scatter"
         )
         plot_dict = plot.to_plotly_json()
         self.assertIsInstance(plot, plotly.graph_objects.Figure)
@@ -859,7 +859,7 @@ class TestDIANNDataSet(BaseTestDataSet.BaseTest):
     def test_plot_intensity_wrong_method(self):
         with self.assertRaises(ValueError):
             self.obj.plot_intensity(
-                protein_id="A0A075B6H7", group="grouping1", method="wrong"
+                feature="A0A075B6H7", group="grouping1", method="wrong"
             )
 
     def test_plot_clustermap_noimputation(self):


### PR DESCRIPTION
The handling of requested ids was very fragile with different LLM inputs.

The new function maps the best matching entry and can also deal with lists.

Some reformatting of the intensity plot included:
- display representation instead of protein id
- adjust width automatically based on number of proteins and groups