### PR TITLE
Modular initial prompt

### DIFF
--- a/alphastats/dataset/keys.py
+++ b/alphastats/dataset/keys.py
@@ -1,3 +1,5 @@
+import traceback
+
 """String constants for accessing columns."""
 
 
@@ -5,6 +7,11 @@ class ConstantsClass(type):
     """A metaclass for classes that should only contain string constants."""
 
     def __setattr__(self, name, value):
+        stack = traceback.format_stack()
+        if any("cloudpickle" in line for line in stack):
+            # Allow setting attributes when pickling
+            super().__setattr__(name, value)
+            return
         raise TypeError("Constants class cannot be modified")
 
     def get_values(cls):

--- a/alphastats/gui/pages/06_LLM.py
+++ b/alphastats/gui/pages/06_LLM.py
@@ -192,16 +192,6 @@ st.markdown("##### System and initial prompt")
 st.write(
     "The prompts are generated based on the above selection on genes and Uniprot information."
 )
-if st.button(
-    "Update prompts with selected genes and UniProt information",
-    disabled=is_llm_integration_initialized,
-    help="Regenerate system message and initial prompt based on current selections",
-):
-    _, protein_data_prompt, _ = initialize_initial_prompt_modules(
-        selected_llm_chat, plot_parameters, feature_to_repr_map
-    )
-    st.session_state[StateKeys.PROMPT_PROTEIN_DATA] = protein_data_prompt
-    selected_llm_chat[LLMKeys.PROMPT_PROTEIN_DATA] = protein_data_prompt
 
 with st.expander("System message", expanded=False):
     system_message = st.text_area(
@@ -213,7 +203,17 @@ with st.expander("System message", expanded=False):
 
 # TODO: Regenerate initial prompt on reset
 with st.expander("Initial prompt", expanded=True):
-    initial_prompt = configure_initial_prompt(disabled=is_llm_integration_initialized)
+    generated_experimental_design_prompt, generated_protein_data_prompt, _ = (
+        initialize_initial_prompt_modules(
+            selected_llm_chat, plot_parameters, feature_to_repr_map
+        )
+    )
+
+    initial_prompt = configure_initial_prompt(
+        generated_experimental_design_prompt,
+        generated_protein_data_prompt,
+        disabled=is_llm_integration_initialized,
+    )
 
     # a bit hacky but makes tool calling of `get_uniprot_info_for_search_string` much simpler
     st.session_state[StateKeys.SELECTED_UNIPROT_FIELDS] = selected_llm_chat[

--- a/alphastats/gui/pages/06_LLM.py
+++ b/alphastats/gui/pages/06_LLM.py
@@ -17,7 +17,6 @@ from alphastats.gui.utils.llm_helper import (
     format_analysis_key,
     get_selected_regulated_genes,
     init_llm_chat_state,
-    initialize_initial_prompt_modules,
     on_select_new_analysis_fill_state,
     protein_selector,
     show_llm_chat,
@@ -203,15 +202,10 @@ with st.expander("System message", expanded=False):
 
 # TODO: Regenerate initial prompt on reset
 with st.expander("Initial prompt", expanded=True):
-    generated_experimental_design_prompt, generated_protein_data_prompt, _ = (
-        initialize_initial_prompt_modules(
-            selected_llm_chat, plot_parameters, feature_to_repr_map
-        )
-    )
-
     initial_prompt = configure_initial_prompt(
-        generated_experimental_design_prompt,
-        generated_protein_data_prompt,
+        selected_llm_chat,
+        plot_parameters,
+        feature_to_repr_map,
         disabled=is_llm_integration_initialized,
     )
 

--- a/alphastats/gui/pages/06_LLM.py
+++ b/alphastats/gui/pages/06_LLM.py
@@ -20,7 +20,6 @@ from alphastats.gui.utils.llm_helper import (
     on_select_new_analysis_fill_state,
     protein_selector,
     show_llm_chat,
-    transfer_llm_chat_state_to_session_state,
 )
 from alphastats.gui.utils.state_keys import LLMKeys, SavedAnalysisKeys, StateKeys
 from alphastats.gui.utils.state_utils import (
@@ -82,7 +81,6 @@ if st.session_state[StateKeys.LLM_CHATS].get(selected_analysis_key) is None:
     st.session_state[StateKeys.LLM_CHATS][selected_analysis_key] = {}
 
 selected_llm_chat = st.session_state[StateKeys.LLM_CHATS][selected_analysis_key]
-transfer_llm_chat_state_to_session_state(selected_llm_chat)
 
 volcano_plot: ResultComponent = selected_analysis[SavedAnalysisKeys.RESULT]
 plot_parameters: Dict = selected_analysis[SavedAnalysisKeys.PARAMETERS]
@@ -120,6 +118,10 @@ upregulated_genes = [
 downregulated_genes = [
     key for key in regulated_genes_dict if regulated_genes_dict[key] == "down"
 ]
+
+
+##################################### Initialize LLM chat state and sync session state #####################################
+
 
 init_llm_chat_state(
     selected_llm_chat,

--- a/alphastats/gui/utils/llm_helper.py
+++ b/alphastats/gui/utils/llm_helper.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import os
 import warnings
 from pathlib import Path
-from typing import List, Optional
+from typing import Optional
 
 import pandas as pd
 import streamlit as st
@@ -191,7 +193,7 @@ def protein_selector(
 
 
 def get_df_for_protein_selector(
-    proteins: List[str], selected: List[str]
+    proteins: list[str], selected: list[str]
 ) -> pd.DataFrame:
     """Create a DataFrame for the protein selector.
 
@@ -214,7 +216,7 @@ def get_df_for_protein_selector(
 
 
 def get_display_proteins_html(
-    protein_ids: List[str], is_upregulated: True, annotation_store, feature_to_repr_map
+    protein_ids: list[str], is_upregulated: True, annotation_store, feature_to_repr_map
 ) -> str:
     """
     Get HTML code for displaying a list of proteins, color according to expression.
@@ -273,9 +275,9 @@ def set_api_key(api_key: str = None) -> None:
 
 def llm_connection_test(
     model_name: str,
-    base_url: Optional[str] = None,
-    api_key: Optional[str] = None,
-) -> Optional[str]:
+    base_url: Optional | str = None,
+    api_key: Optional | str = None,
+) -> Optional | str:
     """Test the connection to the LLM API, return None in case of success, error message otherwise."""
     try:
         llm = LLMIntegration(

--- a/alphastats/gui/utils/llm_helper.py
+++ b/alphastats/gui/utils/llm_helper.py
@@ -544,21 +544,51 @@ def get_selected_regulated_genes(llm_chat: dict) -> tuple[list, dict]:
     return selected_genes, regulated_genes_dict
 
 
-def configure_initial_prompt(disabled: bool) -> None:
-    experimental_design_prompt = st.text_area(
-        "Please explain your experimental design",
-        height=100,
-        disabled=disabled,
-        key=StateKeys.PROMPT_EXPERIMENTAL_DESIGN,
-        on_change=on_change_save_state,
-    )
-    protein_data_prompt = st.text_area(
-        "Please edit your selection above and update the prompt",
-        height=200,
-        disabled=disabled,
-        key=StateKeys.PROMPT_PROTEIN_DATA,
-        on_change=on_change_save_state,
-    )
+def configure_initial_prompt(
+    generated_experimental_design_prompt: str,
+    generated_protein_data_prompt: str,
+    *,
+    disabled: bool,
+) -> None:
+    c1, c2 = st.columns((5, 1))
+    with c2:
+        st.markdown("#####")
+        if st.button(
+            "Regenerate experimental design prompt from analysis parameters",
+            disabled=disabled,
+        ):
+            st.session_state[StateKeys.PROMPT_EXPERIMENTAL_DESIGN] = (
+                generated_experimental_design_prompt
+            )
+            on_change_save_state()
+    with c1:
+        experimental_design_prompt = st.text_area(
+            "Please explain your experimental design",
+            height=100,
+            disabled=disabled,
+            key=StateKeys.PROMPT_EXPERIMENTAL_DESIGN,
+            on_change=on_change_save_state,
+        )
+    c1, c2 = st.columns((5, 1))
+    with c2:
+        st.markdown("#####")
+        if st.button(
+            "Update prompts with selected genes and UniProt information",
+            disabled=disabled,
+            help="Regenerate system message and initial prompt based on current selections",
+        ):
+            st.session_state[StateKeys.PROMPT_PROTEIN_DATA] = (
+                generated_protein_data_prompt
+            )
+            on_change_save_state()
+    with c1:
+        protein_data_prompt = st.text_area(
+            "Please edit your selection above and update the prompt",
+            height=200,
+            disabled=disabled,
+            key=StateKeys.PROMPT_PROTEIN_DATA,
+            on_change=on_change_save_state,
+        )
     initial_instruction = st.text_area(
         "Please provide an initial instruction",
         height=100,

--- a/alphastats/gui/utils/llm_helper.py
+++ b/alphastats/gui/utils/llm_helper.py
@@ -150,7 +150,7 @@ def initialize_initial_prompt_modules(
 
     experimental_design_prompt = _get_experimental_design_prompt(plot_parameters)
 
-    if st.session_state.get(StateKeys.INCLUDE_UNIPROT_INTO_INITIAL_PROMPT, None):
+    if st.session_state.get(StateKeys.INCLUDE_UNIPROT_INTO_INITIAL_PROMPT):
         texts = [
             format_uniprot_annotation(
                 st.session_state[StateKeys.ANNOTATION_STORE][feature],
@@ -180,17 +180,6 @@ def initialize_initial_prompt_modules(
     initial_instruction = _get_initial_instruction(LLMInstructionKeys.SIMPLE)
 
     return experimental_design_prompt, protein_data_prompt, initial_instruction
-
-
-def transfer_llm_chat_state_to_session_state(selected_llm_chat: dict[str, Any]) -> None:
-    """Transfer the state of a given llm_chat to the session state, if it is already initialized.
-
-    This is to get the connection to the model selector right (which operates on the session state).
-    TODO this needs improvement!
-    """
-    if selected_llm_chat.get(LLMKeys.IS_INITIALIZED):
-        st.session_state[StateKeys.MODEL_NAME] = selected_llm_chat[LLMKeys.MODEL_NAME]
-        st.session_state[StateKeys.MAX_TOKENS] = selected_llm_chat[LLMKeys.MAX_TOKENS]
 
 
 @st.fragment
@@ -509,6 +498,10 @@ def on_select_new_analysis_fill_state() -> None:
     st.session_state[StateKeys.PROMPT_INSTRUCTIONS] = selected_chat.get(
         LLMKeys.PROMPT_INSTRUCTIONS, None
     )
+    if selected_chat.get(LLMKeys.IS_INITIALIZED):
+        st.session_state[StateKeys.MODEL_NAME] = selected_chat[LLMKeys.MODEL_NAME]
+        st.session_state[StateKeys.MAX_TOKENS] = selected_chat[LLMKeys.MAX_TOKENS]
+
     st.toast("State filled from saved analysis.", icon="🔍")
 
 
@@ -537,7 +530,7 @@ def on_change_save_state() -> None:
         StateKeys.PROMPT_INSTRUCTIONS
     ]
 
-    if not selected_chat.get(LLMKeys.IS_INITIALIZED, False):
+    if not selected_chat.get(LLMKeys.IS_INITIALIZED):
         selected_chat[LLMKeys.MODEL_NAME] = st.session_state[StateKeys.MODEL_NAME]
         selected_chat[LLMKeys.MAX_TOKENS] = st.session_state[StateKeys.MAX_TOKENS]
 

--- a/alphastats/gui/utils/llm_helper.py
+++ b/alphastats/gui/utils/llm_helper.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 import warnings
 from pathlib import Path
-from typing import Optional
+from typing import Any
 
 import pandas as pd
 import streamlit as st
@@ -36,7 +36,7 @@ OLLAMA_BASE_URL = os.getenv("OLLAMA_BASE_URL", "http://localhost:11434")
 
 
 @st.fragment
-def llm_config():
+def llm_config() -> None:
     """Show the configuration options for the LLM interpretation."""
 
     current_model = st.session_state.get(StateKeys.MODEL_NAME, None)
@@ -98,11 +98,11 @@ def format_analysis_key(key: str) -> str:
 
 
 def init_llm_chat_state(
-    selected_llm_chat: dict,
-    upregulated_genes: list,
-    downregulated_genes: list,
-    plot_parameters: dict,
-    feature_to_repr_map: dict,
+    selected_llm_chat: dict[str, Any],
+    upregulated_genes: list[str],
+    downregulated_genes: list[str],
+    plot_parameters: dict[str, Any],
+    feature_to_repr_map: dict[str, str],
 ) -> None:
     """Initialize the state for a given llm_chat."""
     if LLMKeys.RECENT_CHAT_WARNINGS not in selected_llm_chat:
@@ -142,7 +142,9 @@ def init_llm_chat_state(
 
 
 def initialize_initial_prompt_modules(
-    llm_chat: dict, plot_parameters: dict, feature_to_repr_map: dict
+    llm_chat: dict[str, Any],
+    plot_parameters: dict[str, Any],
+    feature_to_repr_map: dict[str, str],
 ) -> None:
     _, regulated_genes_dict = get_selected_regulated_genes(llm_chat)
 
@@ -180,7 +182,7 @@ def initialize_initial_prompt_modules(
     return experimental_design_prompt, protein_data_prompt, initial_instruction
 
 
-def transfer_llm_chat_state_to_session_state(selected_llm_chat: dict) -> None:
+def transfer_llm_chat_state_to_session_state(selected_llm_chat: dict[str, Any]) -> None:
     """Transfer the state of a given llm_chat to the session state, if it is already initialized.
 
     This is to get the connection to the model selector right (which operates on the session state).
@@ -193,7 +195,7 @@ def transfer_llm_chat_state_to_session_state(selected_llm_chat: dict) -> None:
 
 @st.fragment
 def protein_selector(
-    regulated_genes: list, title: str, selected_analysis_key: str, state_key: str
+    regulated_genes: list[str], title: str, selected_analysis_key: str, state_key: str
 ) -> None:
     """Creates a data editor for protein selection and returns the selected proteins.
 
@@ -274,7 +276,10 @@ def get_df_for_protein_selector(
 
 
 def get_display_proteins_html(
-    protein_ids: list[str], is_upregulated: True, annotation_store, feature_to_repr_map
+    protein_ids: list[str],
+    is_upregulated: True,
+    annotation_store: dict[str, dict],
+    feature_to_repr_map: dict[str, str],
 ) -> str:
     """
     Get HTML code for displaying a list of proteins, color according to expression.
@@ -333,9 +338,9 @@ def set_api_key(api_key: str = None) -> None:
 
 def llm_connection_test(
     model_name: str,
-    base_url: Optional | str = None,
-    api_key: Optional | str = None,
-) -> Optional | str:
+    base_url: str | None = None,
+    api_key: str | None = None,
+) -> str | None:
     """Test the connection to the LLM API, return None in case of success, error message otherwise."""
     try:
         llm = LLMIntegration(
@@ -352,7 +357,7 @@ def llm_connection_test(
 
 # Unused now, but could be useful in the future
 # TODO: Remove this by end of year if still unused.
-def get_display_available_uniprot_info(regulated_features: list) -> dict:
+def get_display_available_uniprot_info(regulated_features: list[str]) -> dict:
     """
     Retrieves and formats UniProt information for a list of regulated features.
 
@@ -383,7 +388,7 @@ def get_display_available_uniprot_info(regulated_features: list) -> dict:
 @st.fragment
 def display_uniprot(
     regulated_genes_dict: dict,
-    feature_to_repr_map,
+    feature_to_repr_map: dict,
     model_name: str,
     selected_analysis_key: str,
     *,
@@ -610,8 +615,8 @@ def configure_initial_prompt(
         st.markdown("#####")
         preset = st.selectbox(
             "Select initial instruction",
-            index=LLMInstructionKeys.get_values().index(LLMInstructionKeys.CUSTOM),
             options=LLMInstructionKeys.get_values(),
+            index=LLMInstructionKeys.get_values().index(LLMInstructionKeys.CUSTOM),
             disabled=disabled,
         )
         if preset != LLMInstructionKeys.CUSTOM:
@@ -639,7 +644,7 @@ def show_llm_chat(
     show_all: bool = False,
     show_individual_tokens: bool = False,
     show_prompt: bool = True,
-):
+) -> None:
     """The chat interface for the LLM interpretation."""
 
     # TODO dump to file -> static file name, plus button to do so

--- a/alphastats/gui/utils/state_keys.py
+++ b/alphastats/gui/utils/state_keys.py
@@ -18,8 +18,6 @@ class StateKeys(metaclass=ConstantsClass):
 
     # LLM
     OPENAI_API_KEY = "openai_api_key"  # pragma: allowlist secret
-    MODEL_NAME = "model_name"
-    MAX_TOKENS = "max_tokens"
 
     LLM_CHATS = "llm_chats"
 
@@ -29,6 +27,11 @@ class StateKeys(metaclass=ConstantsClass):
     # Mirrored by LLMKeys where they are stored in a chat specific manner
     SELECTED_UNIPROT_FIELDS = "selected_uniprot_fields"
     INCLUDE_UNIPROT_INTO_INITIAL_PROMPT = "include_uniprot"
+    MODEL_NAME = "model_name"
+    MAX_TOKENS = "max_tokens"
+    PROMPT_EXPERIMENTAL_DESIGN = "prompt_experimental_design"
+    PROMPT_PROTEIN_DATA = "prompt_protein_data"
+    PROMPT_INSTRUCTIONS = "prompt_instructions"
 
 
 class LLMKeys(metaclass=ConstantsClass):
@@ -45,6 +48,9 @@ class LLMKeys(metaclass=ConstantsClass):
     INCLUDE_UNIPROT_INTO_INITIAL_PROMPT = "include_uniprot"
     MODEL_NAME = "model_name"
     MAX_TOKENS = "max_tokens"
+    PROMPT_EXPERIMENTAL_DESIGN = "prompt_experimental_design"
+    PROMPT_PROTEIN_DATA = "prompt_protein_data"
+    PROMPT_INSTRUCTIONS = "prompt_instructions"
 
 
 class SavedAnalysisKeys(metaclass=ConstantsClass):

--- a/alphastats/gui/utils/state_keys.py
+++ b/alphastats/gui/utils/state_keys.py
@@ -1,10 +1,7 @@
 """Keys functions for the session state."""
 
-import uuid
-
 from alphastats.dataset.keys import ConstantsClass
 from alphastats.gui.utils.preprocessing_helper import PREPROCESSING_STEPS
-from alphastats.llm.llm_integration import Models
 from alphastats.llm.uniprot_utils import ExtractedUniprotFields
 
 
@@ -80,21 +77,3 @@ class DefaultStates(metaclass=ConstantsClass):
         PREPROCESSING_STEPS.LOG2_TRANSFORM,
         PREPROCESSING_STEPS.DROP_UNMEASURED_FEATURES,
     ]
-
-
-INIT_STATES = {
-    StateKeys.USER_SESSION_ID: str(uuid.uuid4()),
-    StateKeys.ORGANISM: 9606,  # human
-    StateKeys.WORKFLOW: DefaultStates.WORKFLOW.copy(),
-    StateKeys.SAVED_ANALYSES: {},
-    StateKeys.LLM_CHATS: {},
-    StateKeys.ANNOTATION_STORE: {},
-    StateKeys.MAX_TOKENS: 10000,
-    StateKeys.MODEL_NAME: (
-        Models.GPT4O
-    ),  # TDOO: change to None: this is just for convenience now
-    StateKeys.SELECTED_ANALYSIS: None,
-    StateKeys.PROMPT_EXPERIMENTAL_DESIGN: None,
-    StateKeys.PROMPT_PROTEIN_DATA: None,
-    StateKeys.PROMPT_INSTRUCTIONS: None,
-}

--- a/alphastats/gui/utils/state_keys.py
+++ b/alphastats/gui/utils/state_keys.py
@@ -1,7 +1,10 @@
 """Keys functions for the session state."""
 
+import uuid
+
 from alphastats.dataset.keys import ConstantsClass
 from alphastats.gui.utils.preprocessing_helper import PREPROCESSING_STEPS
+from alphastats.llm.llm_integration import Models
 from alphastats.llm.uniprot_utils import ExtractedUniprotFields
 
 
@@ -77,3 +80,21 @@ class DefaultStates(metaclass=ConstantsClass):
         PREPROCESSING_STEPS.LOG2_TRANSFORM,
         PREPROCESSING_STEPS.DROP_UNMEASURED_FEATURES,
     ]
+
+
+INIT_STATES = {
+    StateKeys.USER_SESSION_ID: str(uuid.uuid4()),
+    StateKeys.ORGANISM: 9606,  # human
+    StateKeys.WORKFLOW: DefaultStates.WORKFLOW.copy(),
+    StateKeys.SAVED_ANALYSES: {},
+    StateKeys.LLM_CHATS: {},
+    StateKeys.ANNOTATION_STORE: {},
+    StateKeys.MAX_TOKENS: 10000,
+    StateKeys.MODEL_NAME: (
+        Models.GPT4O
+    ),  # TDOO: change to None: this is just for convenience now
+    StateKeys.SELECTED_ANALYSIS: None,
+    StateKeys.PROMPT_EXPERIMENTAL_DESIGN: None,
+    StateKeys.PROMPT_PROTEIN_DATA: None,
+    StateKeys.PROMPT_INSTRUCTIONS: None,
+}

--- a/alphastats/gui/utils/state_keys.py
+++ b/alphastats/gui/utils/state_keys.py
@@ -38,8 +38,8 @@ class LLMKeys(metaclass=ConstantsClass):
     """Keys for accessing the session state for LLM."""
 
     LLM_INTEGRATION = "llm_integration"
-    SELECTED_GENES_UP = "selected_genes_up"
-    SELECTED_GENES_DOWN = "selected_genes_down"
+    SELECTED_FEATURES_UP = "selected_features_up"
+    SELECTED_FEATURES_DOWN = "selected_features_down"
     RECENT_CHAT_WARNINGS = "recent_chat_warnings"
 
     IS_INITIALIZED = "is_initialized"

--- a/alphastats/gui/utils/state_utils.py
+++ b/alphastats/gui/utils/state_utils.py
@@ -1,11 +1,8 @@
 """Functions to initialize and empty the session state."""
 
-import uuid
-
 import streamlit as st
 
-from alphastats.gui.utils.state_keys import DefaultStates, StateKeys
-from alphastats.llm.llm_integration import Models
+from alphastats.gui.utils.state_keys import INIT_STATES
 
 
 def empty_session_state() -> None:
@@ -17,31 +14,6 @@ def empty_session_state() -> None:
 
 def init_session_state() -> None:
     """Initialize the session state if not done yet."""
-    if StateKeys.USER_SESSION_ID not in st.session_state:
-        st.session_state[StateKeys.USER_SESSION_ID] = str(uuid.uuid4())
-
-    if StateKeys.ORGANISM not in st.session_state:
-        st.session_state[StateKeys.ORGANISM] = 9606  # human
-
-    if StateKeys.WORKFLOW not in st.session_state:
-        st.session_state[StateKeys.WORKFLOW] = DefaultStates.WORKFLOW.copy()
-
-    if StateKeys.SAVED_ANALYSES not in st.session_state:
-        st.session_state[StateKeys.SAVED_ANALYSES] = {}
-
-    if StateKeys.LLM_CHATS not in st.session_state:
-        st.session_state[StateKeys.LLM_CHATS] = {}
-
-    if StateKeys.ANNOTATION_STORE not in st.session_state:
-        st.session_state[StateKeys.ANNOTATION_STORE] = {}
-
-    if StateKeys.MAX_TOKENS not in st.session_state:
-        st.session_state[StateKeys.MAX_TOKENS] = 10000
-
-    if StateKeys.MODEL_NAME not in st.session_state:
-        st.session_state[StateKeys.MODEL_NAME] = (
-            Models.GPT4O
-        )  # TDOO: change to None: this is just for convenience now
-
-    if StateKeys.SELECTED_ANALYSIS not in st.session_state:
-        st.session_state[StateKeys.SELECTED_ANALYSIS] = None
+    for key, value in INIT_STATES.items():
+        if key not in st.session_state:
+            st.session_state[key] = value

--- a/alphastats/gui/utils/state_utils.py
+++ b/alphastats/gui/utils/state_utils.py
@@ -1,8 +1,11 @@
 """Functions to initialize and empty the session state."""
 
+import uuid
+
 import streamlit as st
 
-from alphastats.gui.utils.state_keys import INIT_STATES
+from alphastats.gui.utils.state_keys import DefaultStates, StateKeys
+from alphastats.llm.llm_integration import Models
 
 
 def empty_session_state() -> None:
@@ -10,6 +13,24 @@ def empty_session_state() -> None:
     for key in st.session_state:
         del st.session_state[key]
     st.empty()
+
+
+INIT_STATES = {
+    StateKeys.USER_SESSION_ID: str(uuid.uuid4()),
+    StateKeys.ORGANISM: 9606,  # human
+    StateKeys.WORKFLOW: DefaultStates.WORKFLOW.copy(),
+    StateKeys.SAVED_ANALYSES: {},
+    StateKeys.LLM_CHATS: {},
+    StateKeys.ANNOTATION_STORE: {},
+    StateKeys.MAX_TOKENS: 10000,
+    StateKeys.MODEL_NAME: (
+        Models.GPT4O
+    ),  # TDOO: change to None: this is just for convenience now
+    StateKeys.SELECTED_ANALYSIS: None,
+    StateKeys.PROMPT_EXPERIMENTAL_DESIGN: None,
+    StateKeys.PROMPT_PROTEIN_DATA: None,
+    StateKeys.PROMPT_INSTRUCTIONS: None,
+}
 
 
 def init_session_state() -> None:

--- a/alphastats/gui/utils/state_utils.py
+++ b/alphastats/gui/utils/state_utils.py
@@ -1,6 +1,7 @@
 """Functions to initialize and empty the session state."""
 
 import uuid
+from copy import deepcopy
 
 import streamlit as st
 
@@ -37,4 +38,7 @@ def init_session_state() -> None:
     """Initialize the session state if not done yet."""
     for key, value in INIT_STATES.items():
         if key not in st.session_state:
-            st.session_state[key] = value
+            try:
+                st.session_state[key] = deepcopy(value)
+            except AttributeError:
+                st.session_state[key] = value

--- a/alphastats/llm/prompts.py
+++ b/alphastats/llm/prompts.py
@@ -1,11 +1,14 @@
 """This module contains functions to generate prompts for the LLM model."""
 
+from __future__ import annotations
+
 import os
-from typing import Any, Dict, List
+from typing import Any, Optional
 
 from openai.types.chat import ChatCompletionMessageToolCall
 
 from alphastats.dataset.dataset import DataSet
+from alphastats.dataset.keys import ConstantsClass
 from alphastats.llm.llm_utils import get_subgroups_for_each_group
 
 
@@ -27,7 +30,7 @@ def get_system_message(dataset: DataSet) -> str:
 
 
 def _get_experimental_design_prompt(
-    parameter_dict: Dict[str, Any],
+    parameter_dict: dict[str, Any],
 ) -> str:
     group1 = parameter_dict["group1"]
     group2 = parameter_dict["group2"]
@@ -39,8 +42,8 @@ def _get_experimental_design_prompt(
 
 
 def _get_protein_data_prompt(
-    upregulated_genes: List[str],
-    downregulated_genes: List[str],
+    upregulated_genes: list[str],
+    downregulated_genes: list[str],
     uniprot_info: str,
 ):
     """Get the initial prompt for the LLM model."""
@@ -62,11 +65,27 @@ def _get_protein_data_prompt(
     )
 
 
-def _get_initial_instruction():
-    return (
+class LLMInstructionKeys(metaclass=ConstantsClass):
+    """Keys for the LLM instructions."""
+
+    SIMPLE = "simple"
+    CUSTOM = "customize prompt"
+
+
+LLMInstructions = {
+    LLMInstructionKeys.SIMPLE: (
         "Help us understand the potential connections between these proteins and how they might be contributing "
         "to the differences. After that provide a high level summary."
-    )
+    ),
+    LLMInstructionKeys.CUSTOM: "Please give instructions to the LLM model on how to generate a response.",
+}
+
+
+def _get_initial_instruction(preset: Optional | str = "simple"):
+    if preset == LLMInstructionKeys.SIMPLE:
+        return LLMInstructions[LLMInstructionKeys.SIMPLE]
+    else:
+        return LLMInstructions[LLMInstructionKeys.CUSTOM]
 
 
 def get_initial_prompt(
@@ -80,7 +99,7 @@ def get_initial_prompt(
     )
 
 
-def get_tool_call_message(tool_calls: List[ChatCompletionMessageToolCall]) -> str:
+def get_tool_call_message(tool_calls: list[ChatCompletionMessageToolCall]) -> str:
     """Get a string representation of the tool calls made by the LLM model."""
     return "\n".join(
         [

--- a/alphastats/llm/prompts.py
+++ b/alphastats/llm/prompts.py
@@ -26,16 +26,24 @@ def get_system_message(dataset: DataSet) -> str:
     )
 
 
-def get_initial_prompt(
+def _get_experimental_design_prompt(
     parameter_dict: Dict[str, Any],
+) -> str:
+    group1 = parameter_dict["group1"]
+    group2 = parameter_dict["group2"]
+    column = parameter_dict["column"]
+    return (
+        f"We've recently identified several proteins that appear to be differently regulated in cells "
+        f"when comparing {group1} and {group2} in the {column} group. "
+    )
+
+
+def _get_protein_data_prompt(
     upregulated_genes: List[str],
     downregulated_genes: List[str],
     uniprot_info: str,
 ):
     """Get the initial prompt for the LLM model."""
-    group1 = parameter_dict["group1"]
-    group2 = parameter_dict["group2"]
-    column = parameter_dict["column"]
     if uniprot_info:
         uniprot_instructions = (
             f"We have already retireved relevant information from Uniprot for these proteins:{os.linesep}{os.linesep}{uniprot_info}{os.linesep}{os.linesep}"
@@ -48,13 +56,27 @@ def get_initial_prompt(
             "Please do so for individual proteins if you have little information about a protein or find a protein particularly important in the specific context."
         )
     return (
-        f"We've recently identified several proteins that appear to be differently regulated in cells "
-        f"when comparing {group1} and {group2} in the {column} group. "
         f"From our proteomics experiments, we know that the following ones are upregulated: {', '.join(upregulated_genes)}.{os.linesep}{os.linesep}"
         f"Here is a comma-separated list of proteins that are downregulated: {', '.join(downregulated_genes)}.{os.linesep}{os.linesep}"
-        f"{uniprot_instructions}{os.linesep}{os.linesep}"
-        f"Help us understand the potential connections between these proteins and how they might be contributing "
-        f"to the differences. After that provide a high level summary."
+        f"{uniprot_instructions}"
+    )
+
+
+def _get_initial_instruction():
+    return (
+        "Help us understand the potential connections between these proteins and how they might be contributing "
+        "to the differences. After that provide a high level summary."
+    )
+
+
+def get_initial_prompt(
+    experimental_design_prompt: str,
+    protein_data_prompt: str,
+    initial_instruction: str,
+) -> str:
+    """Get the initial prompt for the LLM model."""
+    return f"{os.linesep}{os.linesep}".join(
+        [experimental_design_prompt, protein_data_prompt, initial_instruction]
     )
 
 

--- a/alphastats/llm/prompts.py
+++ b/alphastats/llm/prompts.py
@@ -45,7 +45,7 @@ def _get_protein_data_prompt(
     upregulated_genes: list[str],
     downregulated_genes: list[str],
     uniprot_info: str,
-):
+) -> str:
     """Get the initial prompt for the LLM model."""
     if uniprot_info:
         uniprot_instructions = (
@@ -81,7 +81,7 @@ LLMInstructions = {
 }
 
 
-def _get_initial_instruction(preset: None | str = "simple"):
+def _get_initial_instruction(preset: str | None = "simple") -> str:
     if preset == LLMInstructionKeys.SIMPLE:
         return LLMInstructions[LLMInstructionKeys.SIMPLE]
     else:

--- a/alphastats/llm/prompts.py
+++ b/alphastats/llm/prompts.py
@@ -42,9 +42,10 @@ def _get_experimental_design_prompt(
 
 
 def _get_protein_data_prompt(
-    upregulated_genes: list[str],
-    downregulated_genes: list[str],
+    upregulated_features: list[str],
+    downregulated_features: list[str],
     uniprot_info: str,
+    feature_to_repr_map: dict,
 ) -> str:
     """Get the initial prompt for the LLM model."""
     if uniprot_info:
@@ -58,6 +59,21 @@ def _get_protein_data_prompt(
             "You have the ability to retrieve curated information from Uniprot about these proteins. "
             "Please do so for individual proteins if you have little information about a protein or find a protein particularly important in the specific context."
         )
+    upregulated_genes = list(
+        map(
+            feature_to_repr_map.get,
+            upregulated_features,
+        )
+    )
+
+    downregulated_genes = (
+        list(
+            map(
+                feature_to_repr_map.get,
+                downregulated_features,
+            )
+        ),
+    )
     return (
         f"From our proteomics experiments, we know that the following ones are upregulated: {', '.join(upregulated_genes)}.{os.linesep}{os.linesep}"
         f"Here is a comma-separated list of proteins that are downregulated: {', '.join(downregulated_genes)}.{os.linesep}{os.linesep}"
@@ -77,7 +93,7 @@ LLMInstructions = {
         "Help us understand the potential connections between these proteins and how they might be contributing "
         "to the differences. After that provide a high level summary."
     ),
-    LLMInstructionKeys.CUSTOM: "Please give instructions to the LLM model on how to generate a response.",
+    LLMInstructionKeys.CUSTOM: "<<<Please give instructions to the LLM model on how to generate a response.>>>",
 }
 
 

--- a/alphastats/llm/prompts.py
+++ b/alphastats/llm/prompts.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import os
-from typing import Any, Optional
+from typing import Any
 
 from openai.types.chat import ChatCompletionMessageToolCall
 
@@ -81,7 +81,7 @@ LLMInstructions = {
 }
 
 
-def _get_initial_instruction(preset: Optional | str = "simple"):
+def _get_initial_instruction(preset: None | str = "simple"):
     if preset == LLMInstructionKeys.SIMPLE:
         return LLMInstructions[LLMInstructionKeys.SIMPLE]
     else:

--- a/alphastats/llm/prompts.py
+++ b/alphastats/llm/prompts.py
@@ -71,13 +71,11 @@ def _get_protein_data_prompt(
         )
     )
 
-    downregulated_genes = (
-        list(
-            map(
-                feature_to_repr_map.get,
-                downregulated_features,
-            )
-        ),
+    downregulated_genes = list(
+        map(
+            feature_to_repr_map.get,
+            downregulated_features,
+        )
     )
     return (
         f"From our proteomics experiments, we know the following:{newline}{newline}"
@@ -136,8 +134,8 @@ LLMInstructions = {
 
 
 def _get_initial_instruction(preset: str | None = "simple") -> str:
-    if preset == LLMInstructionKeys.SIMPLE:
-        return LLMInstructions[LLMInstructionKeys.SIMPLE]
+    if preset in LLMInstructions:
+        return LLMInstructions[preset]
     else:
         return LLMInstructions[LLMInstructionKeys.CUSTOM]
 


### PR DESCRIPTION
To facilitate prompt engineering, the initial prompt is split into several text areas, that can be reset and prefilled individually and are saved with the chat to be persistent.

![image](https://github.com/user-attachments/assets/d2530f63-00d3-49ae-858c-2befdabd3c15)
