### PR TITLE
Uniprot fetching

### DIFF
--- a/alphastats/dataset/dataset.py
+++ b/alphastats/dataset/dataset.py
@@ -502,10 +502,6 @@ class DataSet:
 
         if string in self._feature_to_repr_map:
             return [string]
-        if string in self._protein_to_features_map:
-            return self._protein_to_features_map[string]
-        if string in self._gene_to_features_map:
-            return self._gene_to_features_map[string]
         representation_keys = [
             feature
             for feature, representation in self._feature_to_repr_map.items()
@@ -513,6 +509,10 @@ class DataSet:
         ]
         if representation_keys:
             return representation_keys
+        if string in self._protein_to_features_map:
+            return self._protein_to_features_map[string]
+        if string in self._gene_to_features_map:
+            return self._gene_to_features_map[string]
         raise ValueError(f"Feature {string} is not in the (processed) data.")
 
     def _get_multiple_feature_ids_from_strings(self, features: List) -> List:

--- a/alphastats/dataset/dataset.py
+++ b/alphastats/dataset/dataset.py
@@ -490,7 +490,7 @@ class DataSet:
 
         return volcano_plot.plot
 
-    def _get_feature_ids_from_string(self, string: str) -> List[str]:
+    def _get_feature_ids_from_search_string(self, string: str) -> List[str]:
         """Get the feature id from a string representing a feature.
 
         Goes through id mapping dictionaries and finds the completest match.
@@ -527,7 +527,7 @@ class DataSet:
         protein_ids = []
         for feature in features:
             try:
-                for protein_id in self._get_feature_ids_from_string(feature):
+                for protein_id in self._get_feature_ids_from_search_string(feature):
                     protein_ids.append(protein_id)
             except ValueError:
                 unmapped_features.append(feature)

--- a/alphastats/gui/utils/llm_helper.py
+++ b/alphastats/gui/utils/llm_helper.py
@@ -435,13 +435,13 @@ def display_uniprot(
     selected_analysis_session_state = st.session_state[StateKeys.LLM_CHATS][
         selected_analysis_key
     ]
-    if c1.button("Select all"):
+    if c1.button("Select all", disabled=disabled):
         selected_analysis_session_state[LLMKeys.SELECTED_UNIPROT_FIELDS] = all_fields
         st.rerun(scope="fragment")
-    if c2.button("Select none"):
+    if c2.button("Select none", disabled=disabled):
         selected_analysis_session_state[LLMKeys.SELECTED_UNIPROT_FIELDS] = []
         st.rerun(scope="fragment")
-    if c3.button("Recommended selection"):
+    if c3.button("Recommended selection", disabled=disabled):
         selected_analysis_session_state[LLMKeys.SELECTED_UNIPROT_FIELDS] = (
             DefaultStates.SELECTED_UNIPROT_FIELDS.copy()
         )
@@ -470,13 +470,14 @@ def display_uniprot(
         )
 
     c1, c2 = st.columns((1, 3))
-    with c1, st.expander("Show options", expanded=True):
+    with c1, st.expander("Show options", expanded=not disabled):
         selected_fields = []
         for field in all_fields:
             if st.checkbox(
                 field,
                 value=field
                 in selected_analysis_session_state[LLMKeys.SELECTED_UNIPROT_FIELDS],
+                disabled=disabled,
             ):
                 selected_fields.append(field)
         if set(selected_fields) != set(

--- a/alphastats/llm/llm_functions.py
+++ b/alphastats/llm/llm_functions.py
@@ -80,7 +80,7 @@ def get_uniprot_info_for_search_string(
     dataset: DataSet = st.session_state[StateKeys.DATASET]
 
     try:
-        features = dataset._get_feature_ids_from_string(search_string)
+        features = dataset._get_feature_ids_from_search_string(search_string)
     except ValueError:
         features = [feature.strip() for feature in search_string.split(",")]
 
@@ -89,15 +89,12 @@ def get_uniprot_info_for_search_string(
         annotation, feature = get_annotation_from_uniprot_by_feature_list(features)
         annotation_store[feature] = annotation
 
-    if not fields:
-        fields = list(annotation.keys())
-
     return (
         search_string
         + ": "
         + format_uniprot_annotation(
             annotation,
-            fields=fields,
+            fields=fields if fields is not None else list(annotation.keys()),
         )
     )
 

--- a/alphastats/llm/llm_functions.py
+++ b/alphastats/llm/llm_functions.py
@@ -77,10 +77,12 @@ def get_uniprot_info_for_search_string(
     Returns:
         str: The formatted UniProt information for the feature."""
     annotation_store = st.session_state[StateKeys.ANNOTATION_STORE]
+    dataset: DataSet = st.session_state[StateKeys.DATASET]
 
-    features = st.session_state[StateKeys.DATASET]._get_feature_ids_from_string(
-        search_string
-    )
+    try:
+        features = dataset._get_feature_ids_from_string(search_string)
+    except ValueError:
+        features = [feature.strip() for feature in search_string.split(",")]
 
     annotation = get_annotation_from_store_by_feature_list(features, annotation_store)
     if annotation is None:

--- a/alphastats/llm/llm_functions.py
+++ b/alphastats/llm/llm_functions.py
@@ -128,7 +128,7 @@ def get_general_assistant_functions() -> list[dict]:
                         "fields": {
                             "type": "array",
                             "items": {"type": "string"},
-                            "description": f"A list of UniProt fields to include in the output. If empty, all fields are included. Available fields are {", ".join(ExtractedUniprotFields.get_values())}.",
+                            "description": f"A list of UniProt fields to include in the output. If empty, all fields are included. Available fields are {', '.join(ExtractedUniprotFields.get_values())}.",
                         },
                     },
                     "required": ["search_string"],

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1196,28 +1196,28 @@ class TestGetFeatureIdsFromString(unittest.TestCase):
         }
 
     def test_feature_in_feature_to_repr_map(self):
-        result = self.obj._get_feature_ids_from_string("P5;P6")
+        result = self.obj._get_feature_ids_from_search_string("P5;P6")
         self.assertEqual(result, ["P5;P6"])
 
     def test_feature_in_gene_to_features_map(self):
-        result = self.obj._get_feature_ids_from_string("G5")
+        result = self.obj._get_feature_ids_from_search_string("G5")
         self.assertEqual(result, ["P5;P6"])
 
     def test_feature_in_protein_to_features_map(self):
-        result = self.obj._get_feature_ids_from_string("P5")
+        result = self.obj._get_feature_ids_from_search_string("P5")
         self.assertEqual(result, ["P5;P6"])
 
     def test_gene_with_additional_feature(self):
-        result = self.obj._get_feature_ids_from_string("G6")
+        result = self.obj._get_feature_ids_from_search_string("G6")
         self.assertEqual(result, ["P5;P6", "P6;P7"])
 
     def test_representation_matching_feature(self):
-        result = self.obj._get_feature_ids_from_string("ids:P2")
+        result = self.obj._get_feature_ids_from_search_string("ids:P2")
         self.assertEqual(result, ["P2"])
 
     def test_feature_not_found(self):
         with self.assertRaises(ValueError) as context:
-            self.obj._get_feature_ids_from_string("NonExistentFeature")
+            self.obj._get_feature_ids_from_search_string("NonExistentFeature")
         self.assertEqual(
             str(context.exception),
             "Feature NonExistentFeature is not in the (processed) data.",


### PR DESCRIPTION
Lock uniprot info fragment on LLM initialization.
Add uniprot fields as parameter to llm tool and default to all fields.

In the process:
- deduplicate code for selecting features based on search string
- update type hints