### PR TITLE
Hide old dea

### DIFF
--- a/alphastats/gui/utils/analysis.py
+++ b/alphastats/gui/utils/analysis.py
@@ -597,7 +597,10 @@ class DifferentialExpressionTwoGroupsAnalysis(AbstractGroupCompareAnalysis):
         ), None  # None is for backwards compatibility
 
 
+# TODO: Merge functionality from old DEA and Volcano to new DEA (other tests, multicova) and delete the old classes afterwards.
+
 ANALYSIS_OPTIONS = {
+    # PlottingOptions.VOLCANO_PLOT: VolcanoPlotAnalysis,
     PlottingOptions.PCA_PLOT: PCAPlotAnalysis,
     PlottingOptions.UMAP_PLOT: UMAPPlotAnalysis,
     PlottingOptions.TSNE_PLOT: TSNEPlotAnalysis,
@@ -605,6 +608,7 @@ ANALYSIS_OPTIONS = {
     PlottingOptions.INTENSITY_PLOT: IntensityPlot,
     PlottingOptions.CLUSTERMAP: ClustermapAnalysis,
     PlottingOptions.DENDROGRAM: DendrogramAnalysis,
+    # StatisticOptions.DIFFERENTIAL_EXPRESSION: DifferentialExpressionAnalysis,
     StatisticOptions.TUKEY_TEST: TukeyTestAnalysis,
     StatisticOptions.ANOVA: AnovaAnalysis,
     StatisticOptions.ANCOVA: AncovaAnalysis,

--- a/alphastats/gui/utils/analysis.py
+++ b/alphastats/gui/utils/analysis.py
@@ -598,7 +598,6 @@ class DifferentialExpressionTwoGroupsAnalysis(AbstractGroupCompareAnalysis):
 
 
 ANALYSIS_OPTIONS = {
-    PlottingOptions.VOLCANO_PLOT: VolcanoPlotAnalysis,
     PlottingOptions.PCA_PLOT: PCAPlotAnalysis,
     PlottingOptions.UMAP_PLOT: UMAPPlotAnalysis,
     PlottingOptions.TSNE_PLOT: TSNEPlotAnalysis,
@@ -606,7 +605,6 @@ ANALYSIS_OPTIONS = {
     PlottingOptions.INTENSITY_PLOT: IntensityPlot,
     PlottingOptions.CLUSTERMAP: ClustermapAnalysis,
     PlottingOptions.DENDROGRAM: DendrogramAnalysis,
-    StatisticOptions.DIFFERENTIAL_EXPRESSION: DifferentialExpressionAnalysis,
     StatisticOptions.TUKEY_TEST: TukeyTestAnalysis,
     StatisticOptions.ANOVA: AnovaAnalysis,
     StatisticOptions.ANCOVA: AncovaAnalysis,


### PR DESCRIPTION
This is just to remove them before we release, as they don't perform MHC and should therefore not be used.
Cleaning up the codebase is a major task and will involve salvaging and merging some functionality into the new DEA.